### PR TITLE
feat: 递归寻找配置文件

### DIFF
--- a/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/config/MybatisFlexConfig.java
+++ b/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/config/MybatisFlexConfig.java
@@ -57,7 +57,12 @@ public class MybatisFlexConfig {
             List<File> aptConfigFiles = new ArrayList<>();
             File moduleRoot = new File(aptConfigFileObject.toUri()).getParentFile().getParentFile().getParentFile();
 
-            while (FileUtil.existsBuildFile(moduleRoot)) {
+            // 一直往上递归寻找配置文件，直到到达根目录
+            while (true) {
+                // 如果到达根目录，停止递归
+                if (moduleRoot == null || moduleRoot.getParentFile() == null) {
+                    break;
+                }
                 File aptConfig = new File(moduleRoot, APT_FILE_NAME);
                 if (aptConfig.exists()) {
                     aptConfigFiles.add(aptConfig);


### PR DESCRIPTION
在 Kotlin Gradle 的情况下需要配置 Kotlin kapt 来处理注解。

这个时候 moduleRoot 获取到的目录为 build/tmp/kapt3

修改为递归查找的方式直到找到配置文件。