### PR TITLE
 Fixed：Generate column alias specifications to maintain the user's or…

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/IDialect.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/IDialect.java
@@ -29,6 +29,8 @@ public interface IDialect {
 
     String wrap(String keyword);
 
+    String wrapColumnAlias(String keyword);
+
     default String getRealTable(String table) {
         return TableManager.getRealTable(table);
     }

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/CommonsDialectImpl.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/CommonsDialectImpl.java
@@ -62,6 +62,9 @@ public class CommonsDialectImpl implements IDialect {
         return ASTERISK.equals(keyword) ? keyword : keywordWrap.wrap(keyword);
     }
 
+    public String wrapColumnAlias(String keyword) {
+        return ASTERISK.equals(keyword) ? keyword : keywordWrap.getPrefix() + keyword + keywordWrap.getSuffix();
+    }
 
     @Override
     public String forHint(String hintString) {
@@ -863,7 +866,6 @@ public class CommonsDialectImpl implements IDialect {
 
         return sqlBuilder.toString();
     }
-
 
 
     @Override

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/DistinctQueryColumn.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/DistinctQueryColumn.java
@@ -39,7 +39,7 @@ public class DistinctQueryColumn extends QueryColumn {
         String sql = SqlConsts.DISTINCT + StringUtil.join(SqlConsts.DELIMITER, queryColumns, queryColumn ->
             queryColumn.toSelectSql(queryTables, dialect));
 
-        return sql + WrapperUtil.buildAlias(alias, dialect);
+        return sql + WrapperUtil.buildColumnAlias(alias, dialect);
     }
 
 

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/QueryColumn.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/QueryColumn.java
@@ -946,7 +946,7 @@ public class QueryColumn implements CloneSupport<QueryColumn>, Conditional<Query
 
 
     String toSelectSql(List<QueryTable> queryTables, IDialect dialect) {
-        return toConditionSql(queryTables, dialect) + WrapperUtil.buildAlias(alias, dialect);
+        return toConditionSql(queryTables, dialect) + WrapperUtil.buildColumnAlias(alias, dialect);
     }
 
 

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/RawQueryColumn.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/RawQueryColumn.java
@@ -42,7 +42,7 @@ public class RawQueryColumn extends QueryColumn implements HasParamsColumn {
 
     @Override
     String toSelectSql(List<QueryTable> queryTables, IDialect dialect) {
-        return content + WrapperUtil.buildAlias(alias, dialect);
+        return content + WrapperUtil.buildColumnAlias(alias, dialect);
     }
 
     @Override

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/WrapperUtil.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/WrapperUtil.java
@@ -148,11 +148,15 @@ class WrapperUtil {
     }
 
     static String withAlias(String sql, String alias, IDialect dialect) {
-        return SqlConsts.BRACKET_LEFT + sql + SqlConsts.BRACKET_RIGHT + getAsKeyWord(dialect) + dialect.wrap(alias);
+        return SqlConsts.BRACKET_LEFT + sql + SqlConsts.BRACKET_RIGHT + getAsKeyWord(dialect) + buildColumnAlias(alias, dialect);
     }
 
     static String buildAlias(String alias, IDialect dialect) {
         return StringUtil.isBlank(alias) ? SqlConsts.EMPTY : getAsKeyWord(dialect) + dialect.wrap(alias);
+    }
+
+    static String buildColumnAlias(String alias, IDialect dialect) {
+        return StringUtil.isBlank(alias) ? SqlConsts.EMPTY : getAsKeyWord(dialect) + dialect.wrapColumnAlias(alias);
     }
 
     private static String getAsKeyWord(IDialect dialect) {

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/AccountSqlTester.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/AccountSqlTester.java
@@ -21,13 +21,13 @@ import com.mybatisflex.core.dialect.IDialect;
 import com.mybatisflex.core.dialect.KeywordWrap;
 import com.mybatisflex.core.dialect.LimitOffsetProcessor;
 import com.mybatisflex.core.dialect.impl.CommonsDialectImpl;
-import com.mybatisflex.core.query.CPI;
-import com.mybatisflex.core.query.QueryWrapper;
+import com.mybatisflex.core.dialect.impl.DmDialect;
+import com.mybatisflex.core.dialect.impl.OracleDialect;
+import com.mybatisflex.core.query.*;
 import com.mybatisflex.core.table.DynamicTableProcessor;
 import com.mybatisflex.core.table.TableInfo;
 import com.mybatisflex.core.table.TableInfoFactory;
 import com.mybatisflex.core.table.TableManager;
-import com.mybatisflex.core.query.SqlOperators;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -107,7 +107,8 @@ public class AccountSqlTester {
     public void testSelect1ColumnsSql() {
         QueryWrapper query = new QueryWrapper()
             .select(ACCOUNT.ID, ACCOUNT.USER_NAME,
-                ARTICLE.ID.as("articleId"), ARTICLE.TITLE)
+                ARTICLE.ID.as("articleId"), ARTICLE.TITLE,
+                max(ACCOUNT.AGE).as("ageMax"))
             .from(ACCOUNT.as("a"), ARTICLE.as("b"))
             .where(ACCOUNT.ID.eq(ARTICLE.ACCOUNT_ID));
 
@@ -119,12 +120,39 @@ public class AccountSqlTester {
     @Test
     public void testSelectColumnsAndFunctionsSql() {
         QueryWrapper query = new QueryWrapper()
-            .select(ACCOUNT.ID, ACCOUNT.USER_NAME, max(ACCOUNT.BIRTHDAY), avg(ACCOUNT.SEX).as("sex_avg"))
-            .from(ACCOUNT);
+            .select(ACCOUNT.ID, ACCOUNT.USER_NAME, ACCOUNT.AGE.as("aGe"), max(ACCOUNT.BIRTHDAY).as("Max_BirthDay"), avg(ACCOUNT.SEX).as("sex_avg"))
+            .from(ACCOUNT.as("tableAlias"));
 
-        IDialect dialect = new CommonsDialectImpl();
+        IDialect dialect = new OracleDialect();
         String sql = dialect.forSelectByQuery(query);
         System.out.println(sql);
+    }
+
+    @Test
+    public void testSelectColumnsAndFunctionsSqlAlias() {
+        QueryWrapper query = new QueryWrapper()
+            .select(ACCOUNT.ID, ACCOUNT.USER_NAME, ACCOUNT.AGE.as("aGe"), max(ACCOUNT.BIRTHDAY).as("Max_BirthDay"), avg(ACCOUNT.SEX).as("sex_avg"))
+            .from(ACCOUNT.as("tableAlias"));
+
+        IDialect dialect = new DmDialect();
+        String sql = dialect.forSelectByQuery(query);
+        System.out.println(sql);
+    }
+
+    @Test
+    public void testDistinctColumnAlias() {
+        QueryWrapper queryWrapper = new QueryWrapper()
+            .select(
+                new DistinctQueryColumn(ACCOUNT.SEX).as("sexDis"))
+            .select(  ACCOUNT.USER_NAME.add(ACCOUNT.AGE).as("addAlias"))
+            .select(new RawQueryColumn("abc").as("aBc"))
+            .from(ACCOUNT);
+//        IDialect dialect = new CommonsDialectImpl();
+        IDialect dialect = new OracleDialect();
+//        IDialect dialect = new DmDialect();
+        String sql = dialect.forSelectByQuery(queryWrapper);
+        System.out.println("sql = " + sql);
+
     }
 
 


### PR DESCRIPTION
 Fixed：Generate column alias specifications to maintain the user's original column alias names。

 生成列别名规范，保持用户原始的列别名命名。

[https://gitee.com/mybatis-flex/mybatis-flex/issues/I7VIE8#note_20804861](https://gitee.com/mybatis-flex/mybatis-flex/issues/I7VIE8#note_20804861)