### PR TITLE
Configuration processor and autoconfigure processor should be optional

### DIFF
--- a/mybatis-flex-spring-boot-starter/pom.xml
+++ b/mybatis-flex-spring-boot-starter/pom.xml
@@ -34,11 +34,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure-processor</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
`spring-boot-configuration-processor` and `spring-boot-autoconfigure-processor` should be optional.

see [configuration-metadata](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html#appendix.configuration-metadata.annotation-processor.configuring).

```xml
<dependency>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-configuration-processor</artifactId>
    <optional>true</optional>
</dependency>

<dependency>
    <groupId>org.springframework.boot</groupId>
    <artifactId>spring-boot-autoconfigure-processor</artifactId>
    <optional>true</optional>
</dependency>
```