### PR TITLE
fix: 与spring-data-jpa混用时候，提醒`No bean named 'transactionManager' avail…

### DIFF
--- a/mybatis-flex-spring-boot-starter/src/main/java/com/mybatisflex/spring/boot/FlexTransactionAutoConfiguration.java
+++ b/mybatis-flex-spring-boot-starter/src/main/java/com/mybatisflex/spring/boot/FlexTransactionAutoConfiguration.java
@@ -46,7 +46,7 @@ public class FlexTransactionAutoConfiguration implements TransactionManagementCo
      */
     private final FlexTransactionManager flexTransactionManager = new FlexTransactionManager();
 
-    @Bean
+    @Bean(name = "transactionManager")
     @Override
     public PlatformTransactionManager annotationDrivenTransactionManager() {
         return flexTransactionManager;


### PR DESCRIPTION
…able`错误

1. 在使用了jpa的项目中引入了mybatis-flex后，FlexTransactionAutoConfiguration会初始化一个PlatformTransactionManager，jpa的自动初始化transactionManager就不会执行，但是jpa使用的时候beanName是transactionManager，导致默认情况下会找不到该bean