### PR TITLE
Add support for DB2 10.5 version

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/DbType.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/DbType.java
@@ -42,6 +42,7 @@ public enum DbType {
      * DB2
      */
     DB2("db2", "DB2 数据库"),
+    DB2_1005("db2_1005", "DB2 10.5版本数据库"),
 
     /**
      * H2

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/DialectFactory.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/DialectFactory.java
@@ -16,15 +16,15 @@
 package com.mybatisflex.core.dialect;
 
 
+import java.util.EnumMap;
+import java.util.Map;
+import org.apache.ibatis.util.MapUtil;
 import com.mybatisflex.core.FlexGlobalConfig;
 import com.mybatisflex.core.dialect.impl.CommonsDialectImpl;
+import com.mybatisflex.core.dialect.impl.DB2105Dialect;
 import com.mybatisflex.core.dialect.impl.DmDialect;
 import com.mybatisflex.core.dialect.impl.OracleDialect;
 import com.mybatisflex.core.util.ObjectUtil;
-import org.apache.ibatis.util.MapUtil;
-
-import java.util.EnumMap;
-import java.util.Map;
 
 /**
  * 方言工厂类，用于创建方言
@@ -139,6 +139,8 @@ public class DialectFactory {
             case FIREBIRD:
             case DB2:
                 return new CommonsDialectImpl(KeywordWrap.NONE, LimitOffsetProcessor.DERBY);
+            case DB2_1005:
+                return new DB2105Dialect(KeywordWrap.NONE, DB2105Dialect.DB2105LimitOffsetProcessor.DB2105);
             case SQLSERVER:
                 return new CommonsDialectImpl(KeywordWrap.SQUARE_BRACKETS, LimitOffsetProcessor.SQLSERVER);
             case SQLSERVER_2005:

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/DB2105Dialect.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/DB2105Dialect.java
@@ -1,0 +1,36 @@
+package com.mybatisflex.core.dialect.impl;
+
+import com.mybatisflex.core.dialect.KeywordWrap;
+import com.mybatisflex.core.dialect.LimitOffsetProcessor;
+
+public class DB2105Dialect extends CommonsDialectImpl {
+      //TODO: 根据DatabaseMetaData获取数据库厂商名和版本号
+    public static final String DB2_1005_PRODUCT_VERSION = "1005";
+    public static final String DB2_PRODUCT_NAME = "DB2";
+
+
+    public DB2105Dialect(KeywordWrap keywordWrap, LimitOffsetProcessor limitOffsetProcessor) {
+        super(keywordWrap, limitOffsetProcessor);
+    }
+
+    public interface DB2105LimitOffsetProcessor {
+        LimitOffsetProcessor DB2105 = (dialect, sql, queryWrapper, limitRows, limitOffset) -> {
+            StringBuilder limitSqlFragment = new StringBuilder(
+                    "select * from ( select u_.*,rownumber() over()  as rn from ( ");
+            limitSqlFragment.append(sql);
+            limitSqlFragment.append(" )u_  ) temp_ where temp_.rn between ");
+
+            if (limitRows != null && limitOffset != null) {
+                limitSqlFragment.append(limitOffset + 1);
+                limitSqlFragment.append(" and ");
+                limitSqlFragment.append(limitRows + limitOffset);
+            } else if (limitRows != null) {
+                limitSqlFragment.append("1 and ");
+                limitSqlFragment.append(limitRows);
+            } else {
+                return sql;
+            }
+            return limitSqlFragment;
+        };
+    }
+}


### PR DESCRIPTION
This pull request adds support for the DB2 10.5 version database. It includes a new dialect implementation, `DB2105Dialect`, which handles the specific pagination requirements of DB2 10.5. This allows developers to use the `row_number` window function for pagination instead of the `offset` keyword, which is not supported in DB2 10.5.

This change improves compatibility with DB2 10.5 and provides a more consistent experience for developers using MyBatisFlex with this version of DB2.
