### PR TITLE
Test with TestContainers

### DIFF
--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/pom.xml
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/pom.xml
@@ -83,6 +83,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/pom.xml
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/pom.xml
@@ -95,6 +95,12 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/TestInfrastructure.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/TestInfrastructure.java
@@ -1,0 +1,33 @@
+package com.mybatisflex.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collections;
+
+public class TestInfrastructure {
+
+    static final String FLEX_TEST_DDL = TestInfrastructure.class.getClassLoader().getResource("flex_test.sql").getPath();
+    static final String FIELD_MAPPING_TEST_DDL = TestInfrastructure.class.getClassLoader().getResource("field_mapping_test.sql").getPath();
+    static final String PATIENT_DATA_SPLIT_TEST_DDL = TestInfrastructure.class.getClassLoader().getResource("patient_data_split_test.sql").getPath();
+    static final String DOCKER_INITDB_PATH = "/docker-entrypoint-initdb.d/";
+    static GenericContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:8.2.0"))
+        .waitingFor(Wait.forLogMessage(".*ready for connections.*\\n", 1))
+        .withFileSystemBind(FLEX_TEST_DDL, DOCKER_INITDB_PATH + "flex_test.sql", BindMode.READ_ONLY)
+        .withFileSystemBind(FIELD_MAPPING_TEST_DDL, DOCKER_INITDB_PATH + "field_mapping_test.sql", BindMode.READ_ONLY)
+        .withFileSystemBind(PATIENT_DATA_SPLIT_TEST_DDL, DOCKER_INITDB_PATH + "patient_data_split_test.sql", BindMode.READ_ONLY)
+        .withDatabaseName("flex_test")
+        .withReuse(true)
+        .withPassword("123456");
+
+    @BeforeAll
+    public static void start() {
+        mysql.setPortBindings(Collections.singletonList("3306:3306"));
+        mysql.start();
+    }
+}

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/AccountMapperTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/AccountMapperTest.java
@@ -19,18 +19,16 @@ package com.mybatisflex.test.mapper;
 import com.mybatisflex.core.logicdelete.LogicDeleteManager;
 import com.mybatisflex.core.query.QueryWrapper;
 import com.mybatisflex.core.row.Db;
-import com.mybatisflex.core.row.Row;
+import com.mybatisflex.test.TestInfrastructure;
 import com.mybatisflex.test.model.Account;
 import com.mybatisflex.test.model.AccountVO;
 import com.mybatisflex.test.model.AccountVO2;
-import lombok.val;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.Date;
-import java.util.List;
 
 import static com.mybatisflex.core.query.QueryMethods.*;
 import static com.mybatisflex.test.model.table.AccountTableDef.ACCOUNT;
@@ -44,7 +42,7 @@ import static com.mybatisflex.test.model.table.UserTableDef.USER;
  */
 @SpringBootTest
 @SuppressWarnings("all")
-class AccountMapperTest {
+class AccountMapperTest extends TestInfrastructure {
 
     @Autowired
     private AccountMapper accountMapper;

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/ActiveRecordTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/ActiveRecordTest.java
@@ -18,6 +18,7 @@ package com.mybatisflex.test.mapper;
 
 import com.mybatisflex.core.mybatis.Mappers;
 import com.mybatisflex.core.query.QueryWrapper;
+import com.mybatisflex.test.TestInfrastructure;
 import com.mybatisflex.test.model.Good;
 import com.mybatisflex.test.model.User;
 import org.junit.jupiter.api.Assertions;
@@ -34,7 +35,7 @@ import static com.mybatisflex.test.model.table.UserTableDef.USER;
  * @since 2023-07-23
  */
 @SpringBootTest
-class ActiveRecordTest {
+class ActiveRecordTest extends TestInfrastructure {
 
     @Test
     void testMapper() {

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/CombinedMapperTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/CombinedMapperTest.java
@@ -17,6 +17,7 @@
 package com.mybatisflex.test.mapper;
 
 import com.mybatisflex.core.query.QueryWrapper;
+import com.mybatisflex.test.TestInfrastructure;
 import com.mybatisflex.test.model.Account;
 import com.mybatisflex.test.model.Article;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.List;
 
 @SpringBootTest
-public class CombinedMapperTest {
+public class CombinedMapperTest extends TestInfrastructure {
 
     @Autowired
     private AccountMapper accountMapper;

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/MyAccountMapperTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/MyAccountMapperTest.java
@@ -16,6 +16,7 @@
 
 package com.mybatisflex.test.mapper;
 
+import com.mybatisflex.test.TestInfrastructure;
 import com.mybatisflex.test.model.Account;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @since 2023/4/24 19:37
  */
 @SpringBootTest
-class MyAccountMapperTest {
+class MyAccountMapperTest extends TestInfrastructure {
 
     @Autowired
     private MyAccountMapper mapper;

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/OuterMapperTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/OuterMapperTest.java
@@ -17,7 +17,7 @@
 package com.mybatisflex.test.mapper;
 
 import com.mybatisflex.core.query.QueryWrapper;
-import com.mybatisflex.test.entity.Inner;
+import com.mybatisflex.test.TestInfrastructure;
 import com.mybatisflex.test.entity.Outer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ import static com.mybatisflex.test.entity.table.OuterTableDef.OUTER;
  * @since 2023-07-01
  */
 @SpringBootTest
-class OuterMapperTest {
+class OuterMapperTest extends TestInfrastructure {
 
     @Autowired
     private OuterMapper outerMapper;

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/PatientMapperTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/PatientMapperTest.java
@@ -1,5 +1,6 @@
 package com.mybatisflex.test.mapper;
 
+import com.mybatisflex.test.TestInfrastructure;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -13,7 +14,7 @@ import javax.annotation.Resource;
  */
 @SpringBootTest
 @SuppressWarnings("all")
-public class PatientMapperTest {
+public class PatientMapperTest extends TestInfrastructure {
 
     @Resource
     private PatientMapper patientMapper;

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/QueryChainTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/QueryChainTest.java
@@ -22,10 +22,18 @@ import com.mybatisflex.core.query.QueryWrapper;
 import com.mybatisflex.core.update.UpdateChain;
 import com.mybatisflex.test.model.Gender;
 import com.mybatisflex.test.model.User;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collections;
 
 import static com.mybatisflex.test.model.table.RoleTableDef.ROLE;
 import static com.mybatisflex.test.model.table.UserRoleTableDef.USER_ROLE;
@@ -38,8 +46,27 @@ import static com.mybatisflex.test.model.table.UserTableDef.USER;
 @SpringBootTest
 class QueryChainTest {
 
+    static final String TEST_DDL = QueryChainTest.class.getClassLoader().getResource("flex_test.sql").getPath();
+    static GenericContainer<?> mysql = new GenericContainer<>(DockerImageName.parse("mysql:8.2.0"))
+        .waitingFor(Wait.forLogMessage(".*ready for connections.*\\n", 1))
+        // bind DDL to container /docker-entrypoint-initdb.d and it will execute automatically
+        .withFileSystemBind(TEST_DDL, "/docker-entrypoint-initdb.d/flex_test.sql", BindMode.READ_ONLY)
+        .withEnv("MYSQL_DATABASE", "flex_test")
+        .withEnv("MYSQL_ROOT_PASSWORD", "123456");
+
     @Autowired
     UserMapper userMapper;
+
+    @BeforeAll
+    public static void start() {
+        mysql.setPortBindings(Collections.singletonList("3306:3306"));
+        mysql.start();
+    }
+
+    @AfterAll
+    public static void stop() {
+        mysql.stop();
+    }
 
     @Test
     void testFields() {

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/QueryChainTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/QueryChainTest.java
@@ -20,20 +20,13 @@ import com.mybatisflex.core.field.QueryBuilder;
 import com.mybatisflex.core.query.QueryChain;
 import com.mybatisflex.core.query.QueryWrapper;
 import com.mybatisflex.core.update.UpdateChain;
+import com.mybatisflex.test.TestInfrastructure;
 import com.mybatisflex.test.model.Gender;
 import com.mybatisflex.test.model.User;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
-
-import java.util.Collections;
 
 import static com.mybatisflex.test.model.table.RoleTableDef.ROLE;
 import static com.mybatisflex.test.model.table.UserRoleTableDef.USER_ROLE;
@@ -44,29 +37,10 @@ import static com.mybatisflex.test.model.table.UserTableDef.USER;
  * @since 2023-08-08
  */
 @SpringBootTest
-class QueryChainTest {
-
-    static final String TEST_DDL = QueryChainTest.class.getClassLoader().getResource("flex_test.sql").getPath();
-    static GenericContainer<?> mysql = new GenericContainer<>(DockerImageName.parse("mysql:8.2.0"))
-        .waitingFor(Wait.forLogMessage(".*ready for connections.*\\n", 1))
-        // bind DDL to container /docker-entrypoint-initdb.d and it will execute automatically
-        .withFileSystemBind(TEST_DDL, "/docker-entrypoint-initdb.d/flex_test.sql", BindMode.READ_ONLY)
-        .withEnv("MYSQL_DATABASE", "flex_test")
-        .withEnv("MYSQL_ROOT_PASSWORD", "123456");
+class QueryChainTest extends TestInfrastructure {
 
     @Autowired
     UserMapper userMapper;
-
-    @BeforeAll
-    public static void start() {
-        mysql.setPortBindings(Collections.singletonList("3306:3306"));
-        mysql.start();
-    }
-
-    @AfterAll
-    public static void stop() {
-        mysql.stop();
-    }
 
     @Test
     void testFields() {

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/UserMapperTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/UserMapperTest.java
@@ -18,6 +18,7 @@ package com.mybatisflex.test.mapper;
 
 import com.mybatisflex.core.paginate.Page;
 import com.mybatisflex.core.query.QueryWrapper;
+import com.mybatisflex.test.TestInfrastructure;
 import com.mybatisflex.test.model.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -42,7 +43,7 @@ import static com.mybatisflex.test.model.table.UserTableDef.USER;
  */
 @SpringBootTest
 @SuppressWarnings("all")
-class UserMapperTest {
+class UserMapperTest extends TestInfrastructure {
 
     @Autowired
     private UserMapper userMapper;

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/service/ArticleServiceTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/service/ArticleServiceTest.java
@@ -17,6 +17,7 @@
 package com.mybatisflex.test.service;
 
 import com.mybatisflex.core.query.QueryWrapper;
+import com.mybatisflex.test.TestInfrastructure;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,7 +29,7 @@ import static com.mybatisflex.test.model.table.ArticleTableDef.ARTICLE;
  * @since 2023-07-22
  */
 @SpringBootTest
-class ArticleServiceTest {
+class ArticleServiceTest extends TestInfrastructure {
 
     @Autowired
     ArticleService articleService;

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/service/FieldMappingTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/service/FieldMappingTest.java
@@ -2,6 +2,7 @@ package com.mybatisflex.test.service;
 
 import com.mybatisflex.test.mapper.FieldMappingInnerMapper;
 import com.mybatisflex.test.mapper.FieldMappingMapper;
+import com.mybatisflex.test.TestInfrastructure;
 import com.mybatisflex.test.model.FieldMapping;
 import com.mybatisflex.test.model.FieldMappingInner;
 import org.junit.jupiter.api.Test;
@@ -11,11 +12,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.Date;
 
 @SpringBootTest
-public class FieldMappingTest {
+class FieldMappingTest extends TestInfrastructure {
     @Autowired
     FieldMappingMapper fieldMappingMapper;
     @Autowired
     FieldMappingInnerMapper fieldMappingInnerMapper;
+
     @Test
     void testFieldMapping() {
         String fieldId = FieldMapping.create().saveOpt().get().getId();

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <solon.version>2.5.3</solon.version>
 
         <junit.version>4.13.2</junit.version>
+        <testcontainers.version>1.19.3</testcontainers.version>
         <maven-flatten.version>1.5.0</maven-flatten.version>
     </properties>
 
@@ -186,6 +187,14 @@
                 <artifactId>HikariCP</artifactId>
                 <version>${HikariCP.version}</version>
                 <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
Hi, this PR aims to support #246 , using `TestContainers` to do Integration Test in `mybatis-flex-spring-boot-test`, it will start up a `MySQL` container when the test starts.