### PR TITLE
支持通过FlexConfiguration预注册的自定义typeHandler，同时解决需要带自定义初始化参数的问题

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfoFactory.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfoFactory.java
@@ -435,7 +435,12 @@ public class TableInfoFactory {
                     Class<?> typeHandlerClass = columnAnnotation.typeHandler();
                     Configuration configuration = FlexGlobalConfig.getDefaultConfig().getConfiguration();
                     TypeHandlerRegistry typeHandlerRegistry = configuration.getTypeHandlerRegistry();
-                    typeHandler = typeHandlerRegistry.getInstance(columnInfo.getPropertyType(), typeHandlerClass);
+                    Class<?> propertyType = columnInfo.getPropertyType();
+                    JdbcType jdbcType = columnAnnotation.jdbcType();
+                    typeHandler = typeHandlerRegistry.getTypeHandler(propertyType, jdbcType);
+                    if (typeHandler == null || !typeHandlerClass.isAssignableFrom(typeHandler.getClass())) {
+                        typeHandler = typeHandlerRegistry.getInstance(propertyType, typeHandlerClass);
+                    }
                 }
 
                 columnInfo.setTypeHandler(typeHandler);


### PR DESCRIPTION

场景复现，有如下自定义typeHandler，需要在项目启动动态从配置中加载其属性aesKey的值

```java
@Slf4j
@Setter
@MappedJdbcTypes(value = {JdbcType.UNDEFINED, JdbcType.VARCHAR})
@MappedTypes(value = String.class)
public class AESTypeHandler extends StringTypeHandler {

  
    private String aesKey;

    @Override
    public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType) throws SQLException {
            String encryptedValue = AESUtils.encrypt(parameter, aesKey);
            ps.setString(i, encryptedValue);
    }

    @Override
    public String getNullableResult(ResultSet rs, String columnName) throws SQLException {
            String encryptedValue = rs.getString(columnName);
            return AESUtils.decrypt(encryptedValue, aesKey);
    }

    @Override
    public String getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
            String encryptedValue = rs.getString(columnIndex);
            return AESUtils.decrypt(encryptedValue, aesKey);
    }

    @Override
    public String getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
            String encryptedValue = cs.getString(columnIndex);
            return AESUtils.decrypt(encryptedValue, aesKey);
    }
}
```
然后在Column注解中给某字段指定使用该typeHandler

```java
    /**
     * 邮箱地址
     */
    @Column(typeHandler = AESTypeHandler.class, jdbcType = JdbcType.VARCHAR)
    private String email;
```

 因为typeHandler默认不支持带属性构造函数，只能通过ConfigurationCustomizer手动注册设置已创建好的实例

```java
@Configuration
public class MybatisFlexCustomizer implements ConfigurationCustomizer {

    @Value("${database.aes.key:}")
    private String aesKey;

    @Override
    public void customize(FlexConfiguration flexConfiguration) {
        AESTypeHandler typeHandler = new AESTypeHandler();
        typeHandler.setAesKey(this.aesKey).
        flexConfiguration.getTypeHandlerRegistry().register(typeHandler);
    }
}
```

但实际启动后获取到的AESTypeHandler的实例是自动使用其默认无参构造函数创建的实例，因此拿到的AESTypeHandler实例的aesKey属性值始终是null，即下面这段TableInfoFactory.java中的getInstance。

```java
typeHandler = typeHandlerRegistry.getInstance(columnInfo.getPropertyType(), typeHandlerClass);
```

以上，想通过这个小调整支持自行注册的（可以带额外参数的）typeHandler。