### PR TITLE
修复实体类实现多层级的接口时监听器无法匹配问题

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfo.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfo.java
@@ -1367,7 +1367,7 @@ public class TableInfo {
     public void invokeOnInsertListener(Object entity) {
         List<InsertListener> listeners = MapUtil.computeIfAbsent(insertListenerCache, entityClass, aClass -> {
             List<InsertListener> globalListeners = FlexGlobalConfig.getDefaultConfig()
-                .getSupportedInsertListener(entityClass, CollectionUtil.isNotEmpty(onInsertListeners));
+                .getSupportedInsertListener(entityClass);
             List<InsertListener> allListeners = CollectionUtil.merge(onInsertListeners, globalListeners);
             Collections.sort(allListeners);
             return allListeners;
@@ -1381,7 +1381,7 @@ public class TableInfo {
     public void invokeOnUpdateListener(Object entity) {
         List<UpdateListener> listeners = MapUtil.computeIfAbsent(updateListenerCache, entityClass, aClass -> {
             List<UpdateListener> globalListeners = FlexGlobalConfig.getDefaultConfig()
-                .getSupportedUpdateListener(entityClass, CollectionUtil.isNotEmpty(onUpdateListeners));
+                .getSupportedUpdateListener(entityClass);
             List<UpdateListener> allListeners = CollectionUtil.merge(onUpdateListeners, globalListeners);
             Collections.sort(allListeners);
             return allListeners;
@@ -1395,7 +1395,7 @@ public class TableInfo {
     public Object invokeOnSetListener(Object entity, String property, Object value) {
         List<SetListener> listeners = MapUtil.computeIfAbsent(setListenerCache, entityClass, aClass -> {
             List<SetListener> globalListeners = FlexGlobalConfig.getDefaultConfig()
-                .getSupportedSetListener(entityClass, CollectionUtil.isNotEmpty(onSetListeners));
+                .getSupportedSetListener(entityClass);
             List<SetListener> allListeners = CollectionUtil.merge(onSetListeners, globalListeners);
             Collections.sort(allListeners);
             return allListeners;

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/core/FlexGlobalConfigTest.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/core/FlexGlobalConfigTest.java
@@ -1,0 +1,77 @@
+package com.mybatisflex.core;
+
+import com.mybatisflex.annotation.UpdateListener;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * 全局配置测试用例
+ *
+ * @author 阮胜
+ * @since 2024-02-19
+ */
+public class FlexGlobalConfigTest {
+
+    @Test
+    public void testGetSupportedUpdateListener1() {
+        FlexGlobalConfig flexGlobalConfig = new FlexGlobalConfig();
+        flexGlobalConfig.registerUpdateListener(new CustomEntityListener(), Staff.class);
+        List<UpdateListener> supportedUpdateListener = flexGlobalConfig.getSupportedUpdateListener(Staff.class);
+        Assert.assertEquals(supportedUpdateListener.size(), 1);
+    }
+
+    @Test
+    public void testGetSupportedUpdateListener2() {
+        FlexGlobalConfig flexGlobalConfig = new FlexGlobalConfig();
+        flexGlobalConfig.registerUpdateListener(new CustomEntityListener(), IBaseEntity.class);
+        List<UpdateListener> supportedUpdateListener = flexGlobalConfig.getSupportedUpdateListener(Staff.class);
+        Assert.assertEquals(supportedUpdateListener.size(), 1);
+    }
+
+    @Test
+    public void testGetSupportedUpdateListener3() {
+        FlexGlobalConfig flexGlobalConfig = new FlexGlobalConfig();
+        flexGlobalConfig.registerUpdateListener(new CustomEntityListener(), Dept.class);
+        List<UpdateListener> supportedUpdateListener = flexGlobalConfig.getSupportedUpdateListener(Dept.class);
+        Assert.assertEquals(supportedUpdateListener.size(), 1);
+    }
+
+    @Test
+    public void testGetSupportedUpdateListener4() {
+        FlexGlobalConfig flexGlobalConfig = new FlexGlobalConfig();
+        flexGlobalConfig.registerUpdateListener(new CustomEntityListener(), IGeneralEntity.class);
+        List<UpdateListener> supportedUpdateListener = flexGlobalConfig.getSupportedUpdateListener(Dept.class);
+        Assert.assertEquals(supportedUpdateListener.size(), 1);
+    }
+
+    @Test
+    public void testGetSupportedUpdateListener5() {
+        FlexGlobalConfig flexGlobalConfig = new FlexGlobalConfig();
+        flexGlobalConfig.registerUpdateListener(new CustomEntityListener(), IBaseEntity.class);
+        List<UpdateListener> supportedUpdateListener = flexGlobalConfig.getSupportedUpdateListener(Dept.class);
+        Assert.assertEquals(supportedUpdateListener.size(), 1);
+    }
+
+    public static class CustomEntityListener implements UpdateListener {
+        @Override
+        public void onUpdate(Object entity) {
+        }
+    }
+
+    public interface IBaseEntity {
+    }
+
+    public interface IGeneralEntity extends IBaseEntity {
+    }
+
+    public static class Staff implements IBaseEntity {
+
+    }
+
+    public static class Dept implements IGeneralEntity {
+    }
+
+
+}

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/common/ListenerTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/common/ListenerTest.java
@@ -47,7 +47,7 @@ class ListenerTest {
 
         List<InsertListener> insertListeners = MapUtil.computeIfAbsent(tempOnInsertListenerMap, AccountMissingListenerTestModel.class, aClass -> {
             List<InsertListener> globalListeners = FlexGlobalConfig.getDefaultConfig()
-                .getSupportedInsertListener(AccountMissingListenerTestModel.class, CollectionUtil.isNotEmpty(tableInfo.getOnInsertListeners()));
+                .getSupportedInsertListener(AccountMissingListenerTestModel.class);
             List<InsertListener> allListeners = CollectionUtil.merge(tableInfo.getOnInsertListeners(), globalListeners);
             Collections.sort(allListeners);
             return allListeners;


### PR DESCRIPTION
## BUG 复现
顶层接口定义如下：
```java
    public interface IBaseEntity {
    }

    public interface IGeneralEntity extends IBaseEntity {
    }

```
实体类定义：
```java
    public class Dept implements IGeneralEntity {
    }
```
全局配置：注册一个通用实体监听器
```java
        FlexGlobalConfig.getDefaultConfig()
                .registerUpdateListener(new CustomEntityListener(), IBaseEntity.class);
```

## 说明
当使用 `IBaseEntity.class` 进行注册时，监听器将失效，`FlexGlobalConfig` 中对监听器和实体类的匹配逻辑有点问题
该 PR 直接使用 `class.isAssignableFrom( )` 进行匹配（见：`findSupportedListeners`），同时移除多段重复代码