### PR TITLE
Feat: Add TypeHandlerObject value getter 

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/TypeHandlerObject.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/TypeHandlerObject.java
@@ -24,9 +24,9 @@ import java.sql.SQLException;
 
 public class TypeHandlerObject implements Serializable {
 
-    private TypeHandler typeHandler;
-    private Object value;
-    private JdbcType jdbcType;
+    private final TypeHandler typeHandler;
+    private final Object value;
+    private final JdbcType jdbcType;
 
     public TypeHandlerObject(TypeHandler typeHandler, Object value, JdbcType jdbcType) {
         this.typeHandler = typeHandler;
@@ -36,6 +36,10 @@ public class TypeHandlerObject implements Serializable {
 
     public void setParameter(PreparedStatement ps, int i) throws SQLException {
         typeHandler.setParameter(ps, i, value, jdbcType);
+    }
+
+    public Object getValue() {
+        return value;
     }
 
 }


### PR DESCRIPTION
## 背景说明
基于 Mybatis Interceptor 拦截器实现 SQL 日志解析时，Date 日期类型被 `TypeHandlerObject` 包装，且 `TypeHandlerObject` 未暴露获取 value 的方法，导致没法直接获取内部真实对象，希望能够暴露出一个获取 value 的方法，方便扩展用户个性化的一些功能。

![image](https://github.com/mybatis-flex/mybatis-flex/assets/24709538/287e7d2e-abc0-4c61-a9e4-149a4c359ffe)
