### PR TITLE
提供实体类与数据库字段字段映射内容

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfo.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfo.java
@@ -163,6 +163,10 @@ public class TableInfo {
         this.schema = schema;
     }
 
+    public Map<String, String> getPropertyColumnMapping() {
+        return this.propertyColumnMapping;
+    }
+
     public String getTableName() {
         return tableName;
     }


### PR DESCRIPTION
在手动实现自定义动态查询时，暴露该方法，利于代码复用。      
例如我目前实现通用查询的时候，由于传入的类型为`Class<?>`，此时手动实现map查询结果，映射至`Class<?>`实体类时，可根据此方法返回的映射关系手动赋值。