### PR TITLE
feat: 调整关联查询相关功能模块访问级别

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/AbstractRelation.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/AbstractRelation.java
@@ -32,7 +32,7 @@ import java.util.*;
 
 import static com.mybatisflex.core.query.QueryMethods.column;
 
-abstract class AbstractRelation<SelfEntity> {
+public abstract class AbstractRelation<SelfEntity> {
 
     protected String name;
     protected String simpleName;

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/ManyToMany.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/ManyToMany.java
@@ -19,7 +19,7 @@ import com.mybatisflex.annotation.RelationManyToMany;
 
 import java.lang.reflect.Field;
 
-class ManyToMany<SelfEntity> extends ToManyRelation<SelfEntity> {
+public class ManyToMany<SelfEntity> extends ToManyRelation<SelfEntity> {
 
     public ManyToMany(RelationManyToMany annotation, Class<SelfEntity> entityClass, Field relationField) {
         super(getDefaultPrimaryProperty(annotation.selfField(), entityClass, "@RelationManyToMany.selfField can not be empty in field: \"" + entityClass.getName() + "." + relationField.getName() + "\"")

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/ManyToOne.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/ManyToOne.java
@@ -19,7 +19,7 @@ import com.mybatisflex.annotation.RelationManyToOne;
 
 import java.lang.reflect.Field;
 
-class ManyToOne<SelfEntity> extends ToOneRelation<SelfEntity> {
+public class ManyToOne<SelfEntity> extends ToOneRelation<SelfEntity> {
 
     public ManyToOne(RelationManyToOne annotation, Class<SelfEntity> entityClass, Field relationField) {
         super(annotation.selfField()

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/OneToMany.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/OneToMany.java
@@ -19,7 +19,7 @@ import com.mybatisflex.annotation.RelationOneToMany;
 
 import java.lang.reflect.Field;
 
-class OneToMany<SelfEntity> extends ToManyRelation<SelfEntity> {
+public class OneToMany<SelfEntity> extends ToManyRelation<SelfEntity> {
 
 
     public OneToMany(RelationOneToMany annotation, Class<SelfEntity> entityClass, Field relationField) {

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/OneToOne.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/OneToOne.java
@@ -19,7 +19,7 @@ import com.mybatisflex.annotation.RelationOneToOne;
 
 import java.lang.reflect.Field;
 
-class OneToOne<SelfEntity> extends ToOneRelation<SelfEntity> {
+public class OneToOne<SelfEntity> extends ToOneRelation<SelfEntity> {
 
     public OneToOne(RelationOneToOne annotation, Class<SelfEntity> entityClass, Field relationField) {
         super(getDefaultPrimaryProperty(annotation.selfField(), entityClass

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/RelationManager.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/RelationManager.java
@@ -239,7 +239,7 @@ public class RelationManager {
     }
 
 
-    private static List<AbstractRelation> getRelations(Class<?> clazz) {
+    public static List<AbstractRelation> getRelations(Class<?> clazz) {
         return MapUtil.computeIfAbsent(classRelations, clazz, RelationManager::doGetRelations);
     }
 

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/ToManyRelation.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/ToManyRelation.java
@@ -24,7 +24,7 @@ import java.lang.reflect.Field;
 import java.util.*;
 import java.util.function.Function;
 
-class ToManyRelation<SelfEntity> extends AbstractRelation<SelfEntity> {
+public class ToManyRelation<SelfEntity> extends AbstractRelation<SelfEntity> {
 
     protected String mapKeyField;
 

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/ToOneRelation.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/ToOneRelation.java
@@ -21,7 +21,7 @@ import com.mybatisflex.core.util.FieldWrapper;
 import java.lang.reflect.Field;
 import java.util.List;
 
-class ToOneRelation<SelfEntity> extends AbstractRelation<SelfEntity> {
+public class ToOneRelation<SelfEntity> extends AbstractRelation<SelfEntity> {
 
 
     public ToOneRelation(String selfField, String targetSchema, String targetTable, String targetField, String valueField,


### PR DESCRIPTION
将相关功能默认访问级别调整为 `public`，便于第三方框架功能扩展