### PR TITLE
 fix: ClassUtil.newInstance无法生成实例问题修复 https://github.com/mybatis-flex/mybatis-flex/issues/259

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/ClassUtil.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/ClassUtil.java
@@ -22,6 +22,7 @@ import java.lang.reflect.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 /**
@@ -161,8 +162,14 @@ public class ClassUtil {
             }
             // 没有任何构造函数的情况下，去查找 static 工厂方法，满足 lombok 注解的需求
             else {
+                // #issues-259 通过ModifyAttrsRecordProxyFactory.get方法调用时，会给实体类创建一个代理类，
+                // clazz就是这个代理类，下面判断clazz == m.getReturnType()时就为false，所以在这里加了个判断如果是代理类，就获取其父类
+                Optional<Type> isProxy = Arrays.stream(clazz.getGenericInterfaces())
+                    .filter(ProxyObject.class::isInstance)
+                    .findAny();
+                final Class<T> entityClass = isProxy.isPresent() ? (Class<T>) clazz.getGenericSuperclass() : clazz;
                 Method factoryMethod = ClassUtil.getFirstMethod(clazz, m -> m.getParameterCount() == 0
-                    && clazz == m.getReturnType()
+                    && entityClass == m.getReturnType()
                     && Modifier.isPublic(m.getModifiers())
                     && Modifier.isStatic(m.getModifiers()));
                 if (factoryMethod != null) {


### PR DESCRIPTION
通过ModifyAttrsRecordProxyFactory.get方法调用ClassUtil.newInstance时，会给实体类创建一个代理类作为参数，在实体类需要静态方法创建实例的时候，判断clazz == m.getReturnType()时就为false，所以加了个判断如果是代理类，就获取其父类