### PR TITLE
feat: APT 支持从 Resources 目录进行配置

### DIFF
--- a/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/config/MybatisFlexConfig.java
+++ b/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/config/MybatisFlexConfig.java
@@ -50,6 +50,8 @@ public class MybatisFlexConfig {
     protected final Properties properties = new Properties();
 
     public MybatisFlexConfig(Filer filer) {
+        // 先从 resources 目录读取 mybatis-flex.config 配置文件
+        loadConfigFromResource();
         try {
             //target/classes/
             FileObject resource = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "mybatis-flex");
@@ -93,6 +95,21 @@ public class MybatisFlexConfig {
             }
 
         } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void loadConfigFromResource() {
+        Properties resourceProp = new Properties();
+        try (InputStream resourceStream = MybatisFlexConfig.class.getClassLoader().getResourceAsStream(APT_FILE_NAME)) {
+            if (resourceStream == null) {
+                return;
+            }
+            resourceProp.load(resourceStream);
+            if (resourceProp != null && !resourceProp.isEmpty()) {
+                properties.putAll(resourceProp);
+            }
+        } catch (Throwable e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
## 说明
该PR增强了 `mybatis-flex.config` 的配置方式，目前官方文档支持的配置方式：
```
在项目的根目录 （ pom.xml 所在的目录）下创建 `mybatis-flex.config` 配置文件。
```
在企业项目开发中，通常会封装一个统一的 ORM 包，希望可以通过统一的框架包来管理默认的配置，而无需在各个项目中都配置一遍（几十个项目全部配置一遍，后续调整非常麻烦）

该 PR 支持在框架层面的 JAR 包 `resources` 目录下添加 `mybatis-flex.config` （/src/main/resources/mybatis-flex.config）配置文件，所有依赖的子项目会自动读取到该配置。


