### PR TITLE
增加AllSetAfterListener，AllSetAfterListener在entity所有属性全部set完成后调用

### DIFF
--- a/mybatis-flex-annotation/src/main/java/com/mybatisflex/annotation/AllSetAfterListener.java
+++ b/mybatis-flex-annotation/src/main/java/com/mybatisflex/annotation/AllSetAfterListener.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2022-2023, Mybatis-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.mybatisflex.annotation;
+
+/**
+ * 查询实体类数据时，对实体类的属性设置的监听。
+ */
+public interface AllSetAfterListener extends Listener {
+
+
+    /**
+     * 实体类属性设置。
+     *
+     * @param entity   实体类
+     * @return 处理后的实体类
+     */
+     Object onAllSetAfter(Object entity);
+
+}

--- a/mybatis-flex-annotation/src/main/java/com/mybatisflex/annotation/NoneListener.java
+++ b/mybatis-flex-annotation/src/main/java/com/mybatisflex/annotation/NoneListener.java
@@ -18,7 +18,7 @@ package com.mybatisflex.annotation;
 /**
  * 空监听器。
  */
-public final class NoneListener implements InsertListener, UpdateListener, SetListener {
+public final class NoneListener implements InsertListener, UpdateListener, SetListener,AllSetAfterListener {
 
     @Override
     public void onInsert(Object entity) {
@@ -33,6 +33,11 @@ public final class NoneListener implements InsertListener, UpdateListener, SetLi
     @Override
     public Object onSet(Object entity, String property, Object value) {
         return value;
+    }
+
+    @Override
+    public Object onAllSetAfter(Object entity) {
+        return entity;
     }
 
 }

--- a/mybatis-flex-annotation/src/main/java/com/mybatisflex/annotation/Table.java
+++ b/mybatis-flex-annotation/src/main/java/com/mybatisflex/annotation/Table.java
@@ -67,6 +67,12 @@ public @interface Table {
      */
     Class<? extends SetListener>[] onSet() default {};
 
+
+    /**
+     * 监听 entity 的查询数据的所有属性 set 之后行为，用户主动 set 不会触发。
+     */
+    Class<? extends AllSetAfterListener>[] onAllSetAfter() default {};
+
     /**
      * 在某些场景下，我们需要手动编写 Mapper，可以通过这个注解来关闭 APT 的 Mapper 生成。
      */

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexGlobalConfig.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexGlobalConfig.java
@@ -15,11 +15,7 @@
  */
 package com.mybatisflex.core;
 
-import com.mybatisflex.annotation.InsertListener;
-import com.mybatisflex.annotation.KeyType;
-import com.mybatisflex.annotation.Listener;
-import com.mybatisflex.annotation.SetListener;
-import com.mybatisflex.annotation.UpdateListener;
+import com.mybatisflex.annotation.*;
 import com.mybatisflex.core.datasource.FlexDataSource;
 import com.mybatisflex.core.dialect.DbType;
 import com.mybatisflex.core.exception.FlexAssert;
@@ -68,6 +64,7 @@ public class FlexGlobalConfig {
      * entity 的监听器
      */
     private Map<Class<?>, List<SetListener>> entitySetListeners = new ConcurrentHashMap<>();
+    private Map<Class<?>, List<AllSetAfterListener>> entityAllSetAfterListeners = new ConcurrentHashMap<>();
     private Map<Class<?>, List<UpdateListener>> entityUpdateListeners = new ConcurrentHashMap<>();
     private Map<Class<?>, List<InsertListener>> entityInsertListeners = new ConcurrentHashMap<>();
 
@@ -156,6 +153,14 @@ public class FlexGlobalConfig {
         this.entitySetListeners = entitySetListeners;
     }
 
+    public Map<Class<?>, List<AllSetAfterListener>> getEntityAllSetAfterListeners() {
+        return entityAllSetAfterListeners;
+    }
+
+    public void setEntityAllSetAfterListeners(Map<Class<?>, List<AllSetAfterListener>> entityAllSetAfterListeners) {
+        this.entityAllSetAfterListeners = entityAllSetAfterListeners;
+    }
+
     public Map<Class<?>, List<UpdateListener>> getEntityUpdateListeners() {
         return entityUpdateListeners;
     }
@@ -175,6 +180,12 @@ public class FlexGlobalConfig {
     public void registerSetListener(SetListener listener, Class<?>... classes) {
         for (Class<?> aClass : classes) {
             entitySetListeners.computeIfAbsent(aClass, k -> new ArrayList<>()).add(listener);
+        }
+    }
+
+    public void registerAllSetAfterListener(AllSetAfterListener listener, Class<?>... classes) {
+        for (Class<?> aClass : classes) {
+            entityAllSetAfterListeners.computeIfAbsent(aClass, k -> new ArrayList<>()).add(listener);
         }
     }
 
@@ -203,6 +214,17 @@ public class FlexGlobalConfig {
      */
     public List<SetListener> getSupportedSetListener(Class<?> entityClass) {
         return this.findSupportedListeners(entityClass, this.entitySetListeners);
+    }
+
+    /**
+     * 获取支持该 {@code entityClass} 的allSetAfter监听器
+     * <p>当registerClass是entityClass的本身或其超类时，则视为支持</p>
+     *
+     * @param entityClass 实体class
+     * @return AllSetAfterListener
+     */
+    public List<AllSetAfterListener> getSupportedAllSetAfterListener(Class<?> entityClass) {
+        return this.findSupportedListeners(entityClass, this.entityAllSetAfterListeners);
     }
 
     public List<UpdateListener> getUpdateListener(Class<?> entityClass) {

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/FlexDefaultResultSetHandler.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/FlexDefaultResultSetHandler.java
@@ -415,6 +415,9 @@ public class FlexDefaultResultSetHandler extends DefaultResultSetHandler {
                 foundValues = applyAutomaticMappings(rsw, resultMap, metaObject, columnPrefix) || foundValues;
             }
             foundValues = applyPropertyMappings(rsw, resultMap, metaObject, lazyLoader, columnPrefix) || foundValues;
+
+            rowValue = ((FlexWrapperFactory.FlexBeanWrapper)metaObject.getObjectWrapper()).allSetAfter();
+
             foundValues = lazyLoader.size() > 0 || foundValues;
             rowValue = foundValues || configuration.isReturnInstanceForEmptyRow() ? rowValue : null;
         }

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/FlexWrapperFactory.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/FlexWrapperFactory.java
@@ -62,13 +62,18 @@ public class FlexWrapperFactory implements ObjectWrapperFactory {
 
     static class FlexBeanWrapper extends BeanWrapper {
 
-        private final Object entity;
+        private  Object entity;
         private final TableInfo tableInfo;
 
         public FlexBeanWrapper(MetaObject metaObject, Object object) {
             super(metaObject, object);
             this.entity = object;
             this.tableInfo = TableInfoFactory.ofEntityClass(object.getClass());
+        }
+
+        public Object allSetAfter() {
+            this.entity= tableInfo.invokeOnAllSetAfterListener(entity);
+            return this.entity;
         }
 
         @Override

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfoFactory.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfoFactory.java
@@ -15,16 +15,7 @@
  */
 package com.mybatisflex.core.table;
 
-import com.mybatisflex.annotation.Column;
-import com.mybatisflex.annotation.ColumnAlias;
-import com.mybatisflex.annotation.ColumnMask;
-import com.mybatisflex.annotation.Id;
-import com.mybatisflex.annotation.InsertListener;
-import com.mybatisflex.annotation.NoneListener;
-import com.mybatisflex.annotation.SetListener;
-import com.mybatisflex.annotation.Table;
-import com.mybatisflex.annotation.TableRef;
-import com.mybatisflex.annotation.UpdateListener;
+import com.mybatisflex.annotation.*;
 import com.mybatisflex.core.BaseMapper;
 import com.mybatisflex.core.FlexGlobalConfig;
 import com.mybatisflex.core.exception.FlexExceptions;
@@ -275,6 +266,15 @@ public class TableInfoFactory {
                     .collect(Collectors.toList());
                 tableInfo.setOnSetListeners(setListeners);
             }
+
+            if (table.onAllSetAfter().length > 0) {
+                List<AllSetAfterListener> setListeners = Arrays.stream(table.onAllSetAfter())
+                    .filter(listener -> listener != NoneListener.class)
+                    .map(ClassUtil::newInstance)
+                    .collect(Collectors.toList());
+                tableInfo.setOnAllSetAfterListeners(setListeners);
+            }
+
 
             if (StringUtil.isNotBlank(table.dataSource())) {
                 tableInfo.setDataSource(table.dataSource());


### PR DESCRIPTION
增加AllSetAfterListener，类似SetListener，区别在于AllSetAfterListener在entity所有属性全部set完成后调用，可用于set完成后对entity结果的统一处理，如根据entity多个属性生成计算列值