### PR TITLE
解决from一个递归的QueryWrapper作为中间表时，对应的join查询无法追加租户ID的问题

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/provider/EntitySqlProvider.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/provider/EntitySqlProvider.java
@@ -408,13 +408,15 @@ public class EntitySqlProvider {
             tableInfos = new ArrayList<>();
             for (QueryTable queryTable : queryTables) {
                 String tableNameWithSchema = queryTable.getNameWithSchema();
+                TableInfo tableInfo = null;
                 if (StringUtil.isNotBlank(tableNameWithSchema)) {
-                    TableInfo tableInfo = TableInfoFactory.ofTableName(tableNameWithSchema);
-                    if (tableInfo != null) {
+                    tableInfo = TableInfoFactory.ofTableName(tableNameWithSchema);
+                }
+                if (tableInfo == null) {
+                    tableInfo = new TableInfo();
+                }
                         tableInfos.add(tableInfo);
                     }
-                }
-            }
         } else {
             tableInfos = Collections.singletonList(ProviderUtil.getTableInfo(context));
         }

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfo.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfo.java
@@ -967,21 +967,18 @@ public class TableInfo {
         List<QueryTable> queryTables = CPI.getQueryTables(queryWrapper);
         if (queryTables != null && !queryTables.isEmpty()) {
             for (QueryTable queryTable : queryTables) {
-                if (queryTable instanceof SelectQueryTable) {
-                    QueryWrapper childQuery = ((SelectQueryTable) queryTable).getQueryWrapper();
-                    doAppendConditions(entity, childQuery);
-                } else {
                     String nameWithSchema = queryTable.getNameWithSchema();
+                TableInfo tableInfo = null;
                     if (StringUtil.isNotBlank(nameWithSchema)) {
-                        TableInfo tableInfo = TableInfoFactory.ofTableName(nameWithSchema);
-                        if (tableInfo != null) {
+                    tableInfo = TableInfoFactory.ofTableName(nameWithSchema);
+                }
+                if (tableInfo == null) {
+                    tableInfo = new TableInfo();
+                }
                             tableInfo.appendConditions(entity, queryWrapper);
                         }
                     }
                 }
-            }
-        }
-    }
 
 
     public QueryWrapper buildQueryWrapper(Object entity, SqlOperators operators) {


### PR DESCRIPTION
解决from一个递归的QueryWrapper作为中间表时，对应的join查询无法追加租户ID的问题，例如如下SQL，表c和表d都无法追加tenant_id，因为middle_table并没有TableInfo，是建立了一个SelectQueryTable，调用appendCondition追加条件的时候直接进入到了下一层的递归，没有处理同级的join

```
select
    middle_table.a1
    middle_table.b1
from (
    select
        a1
    from
        a
    left join (
        select
            a1,
            b1
        from
            b
    ) b on a.a1 = b.a1
) middle_table
left join (
    select
        a1,
        c1
    from
        c
) c on middle_table.a1 = c.a1
left join d on middle_table.a1 = d.a1
```