### PR TITLE
fix: 修复分页包含 having 语句时，语法依然被优化问题

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/MapperUtil.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/MapperUtil.java
@@ -87,9 +87,10 @@ public class MapperUtil {
         // 获取查询列和分组列，用于判断是否进行优化
         List<QueryColumn> selectColumns = CPI.getSelectColumns(clone);
         List<QueryColumn> groupByColumns = CPI.getGroupByColumns(clone);
-        // 如果有 distinct 语句或者 group by 语句则不优化
+        QueryCondition havingCondition = CPI.getHavingQueryCondition(clone);
+        // 如果有 distinct、group by、having 等语句则不优化
         // 这种一旦优化了就会造成 count 语句查询出来的值不对
-        if (hasDistinct(selectColumns) || hasGroupBy(groupByColumns)) {
+        if (hasDistinct(selectColumns) || hasGroupBy(groupByColumns) || havingCondition != null) {
             return rawCountQueryWrapper(clone);
         }
         // 判断能不能清除 join 语句


### PR DESCRIPTION
## 问题概述
错误的SQL语法执行分页时，count 优化后变成正常的语法被执行

## 问题复现：

```
select *
from "test"."order" as "t1"
having sum("t1"."total_cost") >= 10
```
上面的语法在不分页情况下将抛出异常（因为 having 必须配合 group by 使用）
```
ERROR: column "t1.total_cost" must appear in the GROUP BY clause or be used in an aggregate function
```
但是在分页时触发了 Count 语法优化逻辑，优化后的语法如下：
```
select count(*) as "total"
from "meta"."scm_drug_purchase_master" as "t1"
having sum("t1"."purchase_total_cost") >= 10
```
此时数据库不会抛出异常，被当做是一个正常的语法执行了

## 预期结果
如果 SQL 语法本身就是错误的，那么分页语法应该不做优化，直接使用 select count(*) from ( 原始SQL ) 执行