### PR TITLE
feat(mybatis-flex-core): 增加updateBatch方法是否忽略null字段的可配置性

### DIFF
--- a/docs/zh/base/service.md
+++ b/docs/zh/base/service.md
@@ -20,15 +20,15 @@ public interface IAccountService extends IService<Account> {
 
 ```java
 @Component
-public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account> 
+public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account>
         implements IAccountService {
-    
+
     @Override
     public List<Account> customMethod() {
        // 返回 id >= 100 的数据
        return list(ACCOUNT.ID.ge(100));
     }
-    
+
 }
 ```
 
@@ -64,7 +64,9 @@ public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account>
 - **update(entity, query)**：根据 `QueryWrapper` 构建的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
 - **update(entity, condition)**：根据 `QueryCondition` 构建的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
 - **updateBatch(entities)**：批量保存多条数据，要求主键值不能为空，否则会抛出异常；同时，数据为 null 的字段不会更新到数据库。
-- **updateBatch(entities, size)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；同时，数据为 null 的字段不会更新到数据库。。
+- **updateBatch(entities, ignoreNulls)**：批量保存多条数据，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
+- **updateBatch(entities, size)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；同时，数据为 null 的字段不会更新到数据库。
+- **updateBatch(entities, size, ignoreNulls)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
 
 
 ## 查询数据

--- a/docs/zh/base/service.md
+++ b/docs/zh/base/service.md
@@ -20,15 +20,15 @@ public interface IAccountService extends IService<Account> {
 
 ```java
 @Component
-public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account>
+public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account> 
         implements IAccountService {
-
+    
     @Override
     public List<Account> customMethod() {
        // 返回 id >= 100 的数据
        return list(ACCOUNT.ID.ge(100));
     }
-
+    
 }
 ```
 
@@ -63,8 +63,8 @@ public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account>
 - **update(entity, map)**：根据 `Map<字段名，值>` 组成的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
 - **update(entity, query)**：根据 `QueryWrapper` 构建的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
 - **update(entity, condition)**：根据 `QueryCondition` 构建的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
-- **updateBatch(entities, ignoreNulls)**：批量保存多条数据，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
-- **updateBatch(entities, size, ignoreNulls)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
+- **updateBatch(entities)**：批量保存多条数据，要求主键值不能为空，否则会抛出异常；同时，数据为 null 的字段不会更新到数据库。
+- **updateBatch(entities, size)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；同时，数据为 null 的字段不会更新到数据库。。
 
 
 ## 查询数据

--- a/docs/zh/base/service.md
+++ b/docs/zh/base/service.md
@@ -20,15 +20,15 @@ public interface IAccountService extends IService<Account> {
 
 ```java
 @Component
-public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account> 
+public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account>
         implements IAccountService {
-    
+
     @Override
     public List<Account> customMethod() {
        // 返回 id >= 100 的数据
        return list(ACCOUNT.ID.ge(100));
     }
-    
+
 }
 ```
 
@@ -63,8 +63,8 @@ public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account>
 - **update(entity, map)**：根据 `Map<字段名，值>` 组成的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
 - **update(entity, query)**：根据 `QueryWrapper` 构建的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
 - **update(entity, condition)**：根据 `QueryCondition` 构建的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
-- **updateBatch(entities)**：批量保存多条数据，要求主键值不能为空，否则会抛出异常；同时，数据为 null 的字段不会更新到数据库。
-- **updateBatch(entities, size)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；同时，数据为 null 的字段不会更新到数据库。。
+- **updateBatch(entities, ignoreNulls)**：批量保存多条数据，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
+- **updateBatch(entities, size, ignoreNulls)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
 
 
 ## 查询数据

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
@@ -262,11 +262,14 @@ public interface IService<T> {
      * <p>根据数据主键批量更新数据
      *
      * @param entities 实体类对象集合
+     * @param ignoreNulls 是否忽略空字段
+     *                   {@code true} 表示忽略实体类中为 {@code null} 的字段，不更新这些字段。
+     *                   {@code false} 表示不忽略空字段，允许将对应字段更新为 {@code null}。
      * @return boolean {@code true} 更新成功，{@code false} 更新失败。
-     * @apiNote 若实体类属性数据为 {@code null}，该属性不会新到数据库。
+     * @apiNote 若 {@code ignoreNulls} 为 {@code true}，实体类中为 {@code null} 的属性不会更新到数据库。
      */
-    default boolean updateBatch(Collection<T> entities) {
-        return updateBatch(entities, DEFAULT_BATCH_SIZE);
+    default boolean updateBatch(Collection<T> entities, Boolean ignoreNulls) {
+        return updateBatch(entities, DEFAULT_BATCH_SIZE, ignoreNulls);
     }
 
     /**
@@ -274,12 +277,15 @@ public interface IService<T> {
      *
      * @param entities  实体类对象集合
      * @param batchSize 每批次更新数量
+     * @param ignoreNulls 是否忽略空字段
+     *                   {@code true} 表示忽略实体类中为 {@code null} 的字段，不更新这些字段。
+     *                   {@code false} 表示不忽略空字段，允许将对应字段更新为 {@code null}。
      * @return {@code true} 更新成功，{@code false} 更新失败。
-     * @apiNote 若实体类属性数据为 {@code null}，该属性不会新到数据库。
+     * @apiNote 若 {@code ignoreNulls} 为 {@code true}，实体类中为 {@code null} 的属性不会更新到数据库。
      */
-    default boolean updateBatch(Collection<T> entities, int batchSize) {
+    default boolean updateBatch(Collection<T> entities, int batchSize, boolean ignoreNulls) {
         Class<BaseMapper<T>> usefulClass = (Class<BaseMapper<T>>) ClassUtil.getUsefulClass(getMapper().getClass());
-        return SqlUtil.toBool(Db.executeBatch(entities, batchSize, usefulClass, BaseMapper::update));
+        return SqlUtil.toBool(Db.executeBatch(entities, batchSize, usefulClass, (mapper, entity) -> mapper.update(entity, ignoreNulls)));
     }
 
     // ===== 查询（查）操作 =====

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
@@ -272,6 +272,20 @@ public interface IService<T> {
     /**
      * <p>根据数据主键批量更新数据
      *
+     * @param entities 实体类对象集合
+     * @param ignoreNulls 是否忽略空字段
+     *                   {@code true} 表示忽略实体类中为 {@code null} 的字段，不更新这些字段。
+     *                   {@code false} 表示不忽略空字段，允许将对应字段更新为 {@code null}。
+     * @return boolean {@code true} 更新成功，{@code false} 更新失败。
+     * @apiNote 若 {@code ignoreNulls} 为 {@code true}，实体类中为 {@code null} 的属性不会更新到数据库。
+     */
+    default boolean updateBatch(Collection<T> entities, Boolean ignoreNulls) {
+        return updateBatch(entities, DEFAULT_BATCH_SIZE, ignoreNulls);
+    }
+
+    /**
+     * <p>根据数据主键批量更新数据
+     *
      * @param entities  实体类对象集合
      * @param batchSize 每批次更新数量
      * @return {@code true} 更新成功，{@code false} 更新失败。
@@ -280,6 +294,22 @@ public interface IService<T> {
     default boolean updateBatch(Collection<T> entities, int batchSize) {
         Class<BaseMapper<T>> usefulClass = (Class<BaseMapper<T>>) ClassUtil.getUsefulClass(getMapper().getClass());
         return SqlUtil.toBool(Db.executeBatch(entities, batchSize, usefulClass, BaseMapper::update));
+    }
+
+    /**
+     * <p>根据数据主键批量更新数据
+     *
+     * @param entities  实体类对象集合
+     * @param batchSize 每批次更新数量
+     * @param ignoreNulls 是否忽略空字段
+     *                   {@code true} 表示忽略实体类中为 {@code null} 的字段，不更新这些字段。
+     *                   {@code false} 表示不忽略空字段，允许将对应字段更新为 {@code null}。
+     * @return {@code true} 更新成功，{@code false} 更新失败。
+     * @apiNote 若 {@code ignoreNulls} 为 {@code true}，实体类中为 {@code null} 的属性不会更新到数据库。
+     */
+    default boolean updateBatch(Collection<T> entities, int batchSize, boolean ignoreNulls) {
+        Class<BaseMapper<T>> usefulClass = (Class<BaseMapper<T>>) ClassUtil.getUsefulClass(getMapper().getClass());
+        return SqlUtil.toBool(Db.executeBatch(entities, batchSize, usefulClass, (mapper, entity) -> mapper.update(entity, ignoreNulls)));
     }
 
     // ===== 查询（查）操作 =====

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
@@ -262,14 +262,11 @@ public interface IService<T> {
      * <p>根据数据主键批量更新数据
      *
      * @param entities 实体类对象集合
-     * @param ignoreNulls 是否忽略空字段
-     *                   {@code true} 表示忽略实体类中为 {@code null} 的字段，不更新这些字段。
-     *                   {@code false} 表示不忽略空字段，允许将对应字段更新为 {@code null}。
      * @return boolean {@code true} 更新成功，{@code false} 更新失败。
-     * @apiNote 若 {@code ignoreNulls} 为 {@code true}，实体类中为 {@code null} 的属性不会更新到数据库。
+     * @apiNote 若实体类属性数据为 {@code null}，该属性不会新到数据库。
      */
-    default boolean updateBatch(Collection<T> entities, Boolean ignoreNulls) {
-        return updateBatch(entities, DEFAULT_BATCH_SIZE, ignoreNulls);
+    default boolean updateBatch(Collection<T> entities) {
+        return updateBatch(entities, DEFAULT_BATCH_SIZE);
     }
 
     /**
@@ -277,15 +274,12 @@ public interface IService<T> {
      *
      * @param entities  实体类对象集合
      * @param batchSize 每批次更新数量
-     * @param ignoreNulls 是否忽略空字段
-     *                   {@code true} 表示忽略实体类中为 {@code null} 的字段，不更新这些字段。
-     *                   {@code false} 表示不忽略空字段，允许将对应字段更新为 {@code null}。
      * @return {@code true} 更新成功，{@code false} 更新失败。
-     * @apiNote 若 {@code ignoreNulls} 为 {@code true}，实体类中为 {@code null} 的属性不会更新到数据库。
+     * @apiNote 若实体类属性数据为 {@code null}，该属性不会新到数据库。
      */
-    default boolean updateBatch(Collection<T> entities, int batchSize, boolean ignoreNulls) {
+    default boolean updateBatch(Collection<T> entities, int batchSize) {
         Class<BaseMapper<T>> usefulClass = (Class<BaseMapper<T>>) ClassUtil.getUsefulClass(getMapper().getClass());
-        return SqlUtil.toBool(Db.executeBatch(entities, batchSize, usefulClass, (mapper, entity) -> mapper.update(entity, ignoreNulls)));
+        return SqlUtil.toBool(Db.executeBatch(entities, batchSize, usefulClass, BaseMapper::update));
     }
 
     // ===== 查询（查）操作 =====


### PR DESCRIPTION
原始updateBatch方法默认忽略实体类null数值的字段，导致该方法在某些场景（比如数据同步）下不可用。
现添加可配置化，使updateBatch适配更多场景。