### PR TITLE
fix:修复编译器无法正确匹配updateBatch重载方法的问题

### DIFF
--- a/docs/zh/base/service.md
+++ b/docs/zh/base/service.md
@@ -64,9 +64,9 @@ public class AccountServiceImpl extends ServiceImpl<AccountMapper, Account>
 - **update(entity, query)**：根据 `QueryWrapper` 构建的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
 - **update(entity, condition)**：根据 `QueryCondition` 构建的条件更新数据，实体类可以没有主键（如果有也会被忽略），实体类的 null 属性，会自动被忽略。
 - **updateBatch(entities)**：批量保存多条数据，要求主键值不能为空，否则会抛出异常；同时，数据为 null 的字段不会更新到数据库。
-- **updateBatch(entities, ignoreNulls)**：批量保存多条数据，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
+- **updateBatchWithIgnoreNulls(entities, ignoreNulls)**：批量保存多条数据，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
 - **updateBatch(entities, size)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；同时，数据为 null 的字段不会更新到数据库。
-- **updateBatch(entities, size, ignoreNulls)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
+- **updateBatchWithIgnoreNulls(entities, size, ignoreNulls)**：批量保存多条数据，按指定数量切分，要求主键值不能为空，否则会抛出异常；可以选择数据为 null 的字段是否更新到数据库。
 
 
 ## 查询数据

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
@@ -279,8 +279,8 @@ public interface IService<T> {
      * @return boolean {@code true} 更新成功，{@code false} 更新失败。
      * @apiNote 若 {@code ignoreNulls} 为 {@code true}，实体类中为 {@code null} 的属性不会更新到数据库。
      */
-    default boolean updateBatch(Collection<T> entities, Boolean ignoreNulls) {
-        return updateBatch(entities, DEFAULT_BATCH_SIZE, ignoreNulls);
+    default boolean updateBatchWithIgnoreNulls(Collection<T> entities, boolean ignoreNulls) {
+        return updateBatchWithIgnoreNulls(entities, DEFAULT_BATCH_SIZE, ignoreNulls);
     }
 
     /**
@@ -307,7 +307,7 @@ public interface IService<T> {
      * @return {@code true} 更新成功，{@code false} 更新失败。
      * @apiNote 若 {@code ignoreNulls} 为 {@code true}，实体类中为 {@code null} 的属性不会更新到数据库。
      */
-    default boolean updateBatch(Collection<T> entities, int batchSize, boolean ignoreNulls) {
+    default boolean updateBatchWithIgnoreNulls(Collection<T> entities, int batchSize, boolean ignoreNulls) {
         Class<BaseMapper<T>> usefulClass = (Class<BaseMapper<T>>) ClassUtil.getUsefulClass(getMapper().getClass());
         return SqlUtil.toBool(Db.executeBatch(entities, batchSize, usefulClass, (mapper, entity) -> mapper.update(entity, ignoreNulls)));
     }


### PR DESCRIPTION
#384 该提交存在bug:
    1.编译器无法正确匹配updateBatch重载方法的问题；
    2.ignoreNulls参数类型不统一。由Boolean改为boolean。
以下提供例子。
`List<V> updatedData = new ArrayList<>();
...省略中间代码...
if (!updatedData.isEmpty()) {
  LogicDeleteManager.execWithoutLogicDelete(() -> service.updateBatch(updatedData,false));
}
编译报错：不兼容的类型: boolean无法转换为int
...换个重载方法试试...
if (!updatedData.isEmpty()) {
  LogicDeleteManager.execWithoutLogicDelete(() -> service.updateBatch(updatedData,1000, false));
}
编译报错：对于updateBatch(java.util.List<V>,int,boolean), 找不到合适的方法
`