### PR TITLE
feat: 支持在APT中通过表达式选择package层级

### DIFF
--- a/docs/zh/others/apt.md
+++ b/docs/zh/others/apt.md
@@ -26,16 +26,35 @@ MyBatis-Flex 使用了 APT（Annotation Processing Tool）技术，在项目编�
 | processor.mapper.annotation             | 开启 @Mapper 注解        | true/false                                               | false                                |
 | processor.mapper.baseClass              | 自定义 Mapper 的父类       | 全路径类名                                                    | com.mybatisflex.core.BaseMapper      |
 | processor.mapper.package                | 自定义 Mapper 生成的包名     | 合法的包名                                                    | ${entityPackage}.mapper              |
+| processor.tableDef.package              | 生成辅助类的包名             | 合法的包名                                                    | ${entityPackage}.table               |
 | processor.tableDef.propertiesNameStyle  | 生成辅助类的字段风格           | upperCase, lowerCase<br />upperCamelCase, lowerCamelCase | upperCase                            |
 | processor.tableDef.instanceSuffix       | 生成的表对应的变量后缀          | string                                                   | 空字符串                                 |
 | processor.tableDef.classSuffix          | 生成的 TableDef 类的后缀    | string                                                   | TableDef                             |
 | processor.tableDef.ignoreEntitySuffixes | 过滤 Entity 后缀         | string                                                   | -                                    |
 
+对于示例中的包名表达式，说明如下：
+
+1. 仅支持以下配置项使用表达式
+    ```text
+    processor.allInTables.package
+    processor.mapper.package
+    processor.tableDef.package
+    ```
+2. `${entityPackage}`: 表示 Entity 类所在的包名
+3. `${entityPackage.parent}`: 表示 Entity 类所在的上一级包名
+4. `parent` 参数的数量没有限制，但如果超出了可能的层级，则会导致异常
 
 **示例配置:**
 
 假设 Example 类的全限定类名为 `com.mybatisflex.entity.Example`
 
+配置内容如下:
+
+```properties
+processor.allInTables.package=${entityPackage}.table
+processor.mapper.package=${entityPackage.parent}.mapper
+processor.tableDef.package=${entityPackage.parent.parent}.table
+```
 
 生成类的全限定类名如下:
 

--- a/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/builder/ContentBuilder.java
+++ b/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/builder/ContentBuilder.java
@@ -168,8 +168,7 @@ public class ContentBuilder {
      * 构建 Tables 文件常量属性。
      */
     public static void buildTablesField(StringBuilder importBuilder, StringBuilder fieldBuilder, TableInfo tableInfo,
-                                        String tableDefClassSuffix, String tableDefPropertiesNameStyle, String tableDefInstanceSuffix) {
-        String tableDefPackage = StrUtil.buildTableDefPackage(tableInfo.getEntityName());
+                                        String tableDefClassSuffix, String tableDefPropertiesNameStyle, String tableDefInstanceSuffix, String tableDefPackage) {
         String tableDefClassName = tableInfo.getEntitySimpleName().concat(tableDefClassSuffix);
         importBuilder.append("import ").append(tableDefPackage).append('.').append(tableDefClassName).append(";\n");
         String entityComment = tableInfo.getEntityComment();

--- a/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/config/ConfigurationKey.java
+++ b/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/config/ConfigurationKey.java
@@ -78,6 +78,11 @@ public enum ConfigurationKey {
 
 
     /**
+     * 自定义 Class 生成的包名。
+     */
+    TABLE_DEF_PACKAGE("processor.tableDef.package", null),
+
+    /**
      * 生成的 Class 的后缀。
      */
     TABLE_DEF_CLASS_SUFFIX("processor.tableDef.classSuffix", "TableDef"),

--- a/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/util/StrUtil.java
+++ b/mybatis-flex-processor/src/main/java/com/mybatisflex/processor/util/StrUtil.java
@@ -16,6 +16,11 @@
 
 package com.mybatisflex.processor.util;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * 字符串工具类。
  *
@@ -27,6 +32,8 @@ public class StrUtil {
 
     private StrUtil() {
     }
+
+    private static final Pattern PACKAGE_REGEX = Pattern.compile("(?<expression>\\$\\{entityPackage[.parent]*\\})(?<subPackage>.*)");
 
     /**
      * com.mybatisflex.test.entity.Account -> Account
@@ -113,6 +120,40 @@ public class StrUtil {
             }
         }
     }
+
+    /**
+     * 解析包名表达式
+     * <p>将{@code `${entityPackage}`}替换为实际实体包名, 表达式中如果存在一个{@code `.parent`}则缩减包名末尾的一位。</p>
+     * <p>示例：{@code `entityClass = com.test1.test2`}<br>
+     * 1. 对于{@code `packageStr = ${entityPackage}`}处理结果为 {@code `com.test1.test2`}<br>
+     * 2. 对于{@code `packageStr = ${entityPackage.parent}`}处理结果为 {@code `com.test1`}<br>
+     * 3. 对于{@code `packageStr = ${entityPackage.parent}.customize`}处理结果为 {@code `com.test1.customize`}
+     * </p>
+     */
+    public static String processPackageExpression(String entityClass, String packageStr) {
+        String entityPackage = entityClass.substring(0, entityClass.lastIndexOf("."));
+        Matcher matcher = PACKAGE_REGEX.matcher(packageStr);
+        if (!matcher.find()) {
+            return packageStr;
+        }
+        String expression = matcher.group("expression");
+        expression = expression.substring(2, expression.length() - 1);
+        String subPackage = matcher.group("subPackage");
+        List<String> entityPackageSplit = Arrays.asList(entityPackage.split("\\."));
+        while (expression.contains(".parent")) {
+            if (entityPackageSplit.size() == 0) {
+                throw new RuntimeException("Expression [.parent] has exceeded the maximum limit.");
+            }
+            int index = expression.lastIndexOf(".parent");
+            if (index != -1) {
+                expression = expression.substring(0, index);
+                entityPackageSplit = entityPackageSplit.subList(0, entityPackageSplit.size() - 1);
+            }
+        }
+        expression = expression.replace("entityPackage", String.join(".", entityPackageSplit));
+        return expression + subPackage;
+    }
+
 
     public static boolean isGetterMethod(String methodName, String property) {
         if (methodName.startsWith("get") && methodName.length() > 3) {


### PR DESCRIPTION
Link: https://github.com/mybatis-flex/mybatis-flex/issues/388

1. 增加processor.tableDef.package配置
2. 支持在APT中通过表达式选择package层级
支持以下配置项
```
processor.allInTables.package
processor.mapper.package
processor.tableDef.package
```

将`${entityPackage}`替换为实际实体包名, 表达式中如果存在一个`.parent`则缩减包名末尾的一位。

示例：`entityClass = com. test1.test2`
1. 对于`packageStr = ${entityPackage}`处理结果为 `com.test1.test2`
2. 对于`packageStr = ${entityPackage. parent}`处理结果为 `com.test1`
6. 对于`packageStr = ${entityPackage. parent}.customize`处理结果为 `com.test1.customize`