### PR TITLE
增加未匹配列的自定义处理拓展接口

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexGlobalConfig.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexGlobalConfig.java
@@ -23,6 +23,7 @@ import com.mybatisflex.annotation.UpdateListener;
 import com.mybatisflex.core.datasource.FlexDataSource;
 import com.mybatisflex.core.dialect.DbType;
 import com.mybatisflex.core.exception.FlexAssert;
+import com.mybatisflex.core.mybatis.UnMappedColumnHandler;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSessionFactory;
 
@@ -108,6 +109,11 @@ public class FlexGlobalConfig {
      * 默认的乐观锁字段，允许设置 {@code null} 忽略匹配。
      */
     private String versionColumn;
+
+    /**
+     * 未匹配列处理器
+     */
+    private static UnMappedColumnHandler unMappedColumnHandler;
 
     public boolean isPrintBanner() {
         return printBanner;
@@ -321,6 +327,14 @@ public class FlexGlobalConfig {
 
     public void setVersionColumn(String versionColumn) {
         this.versionColumn = versionColumn;
+    }
+
+    public static UnMappedColumnHandler getUnMappedColumnHandler() {
+        return unMappedColumnHandler;
+    }
+
+    public void setUnMappedColumnHandler(UnMappedColumnHandler unMappedColumnHandler) {
+        this.unMappedColumnHandler = unMappedColumnHandler;
     }
 
     public FlexDataSource getDataSource() {

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/UnMappedColumnHandler.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/UnMappedColumnHandler.java
@@ -1,0 +1,15 @@
+package com.mybatisflex.core.mybatis;
+
+import org.apache.ibatis.reflection.MetaObject;
+
+/**
+ * UnMappedColumnHandler
+ * 自定义未匹配列处理
+ * @author ArthurWang
+ * @version 1.0
+ * @date 2024/9/12 9:16
+ **/
+public interface UnMappedColumnHandler {
+
+    void handleUnMappedColumn(MetaObject metaObject, String unmappedColumnName, Object value);
+}

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/java/com/mybatisflex/test/MyConfigurationCustomizer.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/java/com/mybatisflex/test/MyConfigurationCustomizer.java
@@ -23,6 +23,7 @@ import com.mybatisflex.core.datasource.DataSourceProperty;
 import com.mybatisflex.core.mybatis.FlexConfiguration;
 import com.mybatisflex.spring.boot.ConfigurationCustomizer;
 import com.mybatisflex.spring.boot.MyBatisFlexCustomizer;
+import com.mybatisflex.test.unmapped.MyUnMappedColumnHandler;
 import org.apache.ibatis.logging.stdout.StdOutImpl;
 import org.springframework.context.annotation.Configuration;
 
@@ -55,6 +56,7 @@ public class MyConfigurationCustomizer implements ConfigurationCustomizer, MyBat
             return value;
         };
         DataSourceManager.setDecipher(decipher);
+        globalConfig.setUnMappedColumnHandler(new MyUnMappedColumnHandler());
 
     }
 }

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/java/com/mybatisflex/test/model/UnmappedBaseEntity.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/java/com/mybatisflex/test/model/UnmappedBaseEntity.java
@@ -13,18 +13,23 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package com.mybatisflex.core.mybatis;
+package com.mybatisflex.test.model;
 
-import org.apache.ibatis.reflection.MetaObject;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
 
 /**
- * UnMappedColumnHandler
- * 自定义未匹配列处理
- * @author ArthurWang
+ * UnMappedBaseEntity
+ *
+ * @author wy
  * @version 1.0
- * @date 2024/9/12 9:16
+ * @date 2024/9/12 11:36
  **/
-public interface UnMappedColumnHandler {
+@Getter
+@Setter
+public class UnmappedBaseEntity {
 
-    void handleUnMappedColumn(MetaObject metaObject, String unmappedColumnName, Object value);
+    protected Map<String, Object> unmappedMap;
 }

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/java/com/mybatisflex/test/model/UnmappedUser.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/java/com/mybatisflex/test/model/UnmappedUser.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2022-2025, Mybatis-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.mybatisflex.test.model;
+
+import com.mybatisflex.annotation.Id;
+import com.mybatisflex.annotation.KeyType;
+import com.mybatisflex.annotation.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * UnMapped
+ *
+ * @author wy
+ * @version 1.0
+ * @date 2024/9/12 11:28
+ **/
+@Getter
+@Setter
+@Table("tb_unmapped_user")
+public class UnmappedUser extends UnmappedBaseEntity {
+
+    @Id(keyType = KeyType.Auto)
+    private Long id;
+
+    private Integer age;
+
+    private String name;
+
+    @Override
+    public String toString() {
+        return "UnmappedUser{" +
+            "id='" + id + '\'' +
+            ", name='" + name + '\'' +
+            ", age=" + age +
+            (CollectionUtils.isEmpty(unmappedMap) ? "" : ", unmappedMap=" + unmappedMap.toString())
+            + '}';
+    }
+}

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/java/com/mybatisflex/test/unmapped/MyUnMappedColumnHandler.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/java/com/mybatisflex/test/unmapped/MyUnMappedColumnHandler.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2022-2025, Mybatis-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.mybatisflex.test.unmapped;
+
+import com.mybatisflex.core.mybatis.UnMappedColumnHandler;
+import com.mybatisflex.test.model.UnmappedBaseEntity;
+import org.apache.ibatis.reflection.MetaObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * MyUnMappedColumnHandler
+ *
+ * @author wy
+ * @version 1.0
+ * @date 2024/9/12 11:34
+ **/
+public class MyUnMappedColumnHandler implements UnMappedColumnHandler {
+    @Override
+    public void handleUnMappedColumn(MetaObject metaObject, String unmappedColumnName, Object value) {
+        if (metaObject.getOriginalObject() instanceof  UnmappedBaseEntity){
+            Object object =  metaObject.getValue("unmappedMap");
+            if(object == null){
+                Map<String, Object> map = new HashMap<>();
+                map.put(unmappedColumnName, value);
+                metaObject.setValue("unmappedMap", map);
+            }else  {
+                ((Map)object).put(unmappedColumnName, value);
+            }
+        }
+    }
+}

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/resources/unmapped_user.sql
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/main/resources/unmapped_user.sql
@@ -1,0 +1,21 @@
+-- ----------------------------
+-- Table structure for tb_unmapped_user
+-- ----------------------------
+DROP TABLE IF EXISTS `tb_unmapped_user`;
+CREATE TABLE `tb_unmapped_user`
+(
+    `id`        bigint primary key AUTO_INCREMENT,
+    `name`      varchar(100)  NULL DEFAULT NULL,
+    `age`       int NULL DEFAULT NULL,
+    `code`      int NULL DEFAULT NULL
+)
+
+-- ----------------------------
+-- Records of tb_unmapped_user
+-- ----------------------------
+INSERT INTO `tb_unmapped_user`
+VALUES (1, '张三', 28, 64);
+INSERT INTO `tb_unmapped_user`
+VALUES (2, '李四', 15, 128);
+INSERT INTO `tb_unmapped_user`
+VALUES (3, '王五', 9,  256);

--- a/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/UnmappedUserMapperTest.java
+++ b/mybatis-flex-test/mybatis-flex-spring-boot-test/src/test/java/com/mybatisflex/test/mapper/UnmappedUserMapperTest.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2022-2025, Mybatis-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.mybatisflex.test.mapper;
+
+import com.mybatisflex.core.query.QueryColumn;
+import com.mybatisflex.core.query.QueryMethods;
+import com.mybatisflex.core.query.QueryWrapper;
+import com.mybatisflex.test.model.UnmappedUser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static com.mybatisflex.test.model.table.UnmappedUserTableDef.UNMAPPED_USER;
+
+/**
+ * UnMappedUserMapperTest
+ *
+ * @author wy
+ * @version 1.0
+ * @date 2024/9/12 11:39
+ **/
+@SpringBootTest
+@SuppressWarnings("all")
+public class UnmappedUserMapperTest {
+
+    @Autowired
+    private UnmappedUserMapper unmappedUserMapper;
+
+    /**
+     * 额外字段查询，数据库中有，但是实体类中没有
+     * 应用：前端具有一定查询数据库能力时，不改后端代码情况下，返回新增字段数据
+     */
+    @Test
+    void testExtraColumn() {
+        QueryWrapper queryWrapper = QueryWrapper.create()
+            .select(UNMAPPED_USER.ID, UNMAPPED_USER.AGE, UNMAPPED_USER.NAME,
+                // 额外字段查询
+                new QueryColumn("code"))
+            .where(UNMAPPED_USER.ID.in(1, 2, 3));
+        List<UnmappedUser> unmappedUserList = unmappedUserMapper.selectListByQuery(queryWrapper);
+        System.out.println(unmappedUserList);
+    }
+
+    /**
+     * 同名字段
+     * 多数据源下同表同名字段不同含义或者需要同时展示
+     */
+    @Test
+    void testSameColumn() {
+        // 可能多数据源下会存在同表同名字段不同值
+        QueryWrapper queryWrapper = QueryWrapper.create()
+            .select(UNMAPPED_USER.ID, UNMAPPED_USER.AGE, UNMAPPED_USER.NAME,
+                // 同名字段重置
+                UNMAPPED_USER.NAME.as("ext_name"))
+            .where(UNMAPPED_USER.ID.in(1, 2, 3));
+        List<UnmappedUser> unmappedUserList = unmappedUserMapper.selectListByQuery(queryWrapper);
+        System.out.println(unmappedUserList);
+    }
+
+    /**
+     * 计算或者处理的字段
+     * sql中进行处理的字段，不直接映射到实体类上的域
+     */
+    @Test
+    void testCalColumn() {
+        QueryWrapper queryWrapper = QueryWrapper.create()
+            .select(UNMAPPED_USER.ID, UNMAPPED_USER.NAME, UNMAPPED_USER.AGE,
+                // 字段计算结果
+                QueryMethods.case_()
+                    .when(UNMAPPED_USER.AGE.ge(18)).then("adult")
+                    .when(UNMAPPED_USER.AGE.le(14)).then("child")
+                    .else_("juvenile")
+                    .end()
+                    .as("age_group"))
+            .where(UNMAPPED_USER.ID.in(1, 2, 3));
+        List<UnmappedUser> unmappedUserList = unmappedUserMapper.selectListByQuery(queryWrapper);
+        System.out.println(unmappedUserList);
+    }
+
+}


### PR DESCRIPTION
1. 对一些自定义查询时，比如as，as 的字段名在实体类中没有，但是实际需要以另一种方式获取；
2. 对于 数据库中有的字段，但是实体类中未定义的特殊字段，进行自定义处理；
3. 同名字段 在不同源中获取时，以不同名称获取，给予自定义操作。

`QueryWrapper queryWrapper = QueryWrapper.create()
            .select(QueryMethods.column(Example::getId),
                QueryMethods.column(Example::getExampleName),
                QueryMethods.column(Example::getExampleName).as("name_test")));
        List<JamExample> aclineList = exampleMapper.selectListByQuery(queryWrapper);`