### PR TITLE
chore: mybatis-spring升级同步升级mybatis依赖版本为3.5.16,解决issue：https://github.com/mybatis-flex/mybatis-flex/issues/336

### DIFF
--- a/mybatis-flex-spring-boot3-starter/pom.xml
+++ b/mybatis-flex-spring-boot3-starter/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis-spring</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
解决：[https://github.com/mybatis-flex/mybatis-flex/issues/336](https://github.com/mybatis-flex/mybatis-flex/issues/336)，详情见issue评论