### PR TITLE
fix: 修复@EnumValue应用在接口方法上失效

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/handler/CompositeEnumTypeHandler.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/handler/CompositeEnumTypeHandler.java
@@ -39,8 +39,8 @@ public class CompositeEnumTypeHandler<E extends Enum<E>> implements TypeHandler<
         boolean isNotFound = false;
         List<Field> enumDbValueFields = ClassUtil.getAllFields(enumClass, f -> f.getAnnotation(EnumValue.class) != null);
         if (enumDbValueFields.isEmpty()) {
-            List<Method> enumDbValueMethods = ClassUtil.getAllMethods(enumClass, m -> m.getAnnotation(EnumValue.class) != null);
-            if (enumDbValueMethods.isEmpty()) {
+            Method enumDbValueMethod = ClassUtil.getFirstMethodByAnnotation(enumClass, EnumValue.class);
+            if (enumDbValueMethod == null) {
                 isNotFound = true;
             }
         }

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/handler/FlexEnumTypeHandler.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/handler/FlexEnumTypeHandler.java
@@ -26,7 +26,7 @@ import java.sql.SQLException;
 
 public class FlexEnumTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E> {
 
-    private EnumWrapper<E> enumWrapper;
+    private final EnumWrapper<E> enumWrapper;
 
     public FlexEnumTypeHandler(Class<E> enumClass) {
         enumWrapper = EnumWrapper.of(enumClass);

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/EnumWrapper.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/EnumWrapper.java
@@ -30,8 +30,8 @@ public class EnumWrapper<E extends Enum<E>> {
 
     private boolean hasEnumValueAnnotation = false;
 
-    private Class<?> enumClass;
-    private E[] enums;
+    private final Class<?> enumClass;
+    private final E[] enums;
     private Field property;
     private Class<?> propertyType;
     private Method getterMethod;
@@ -71,7 +71,7 @@ public class EnumWrapper<E extends Enum<E>> {
         }
 
         if (!hasEnumValueAnnotation) {
-            Method enumValueMethod = ClassUtil.getFirstMethod(enumClass, method -> method.getAnnotation(EnumValue.class) != null);
+            Method enumValueMethod = ClassUtil.getFirstMethodByAnnotation(enumClass, EnumValue.class);
             if (enumValueMethod != null) {
                 String methodName = enumValueMethod.getName();
                 if (!(methodName.startsWith("get") && methodName.length() > 3)) {
@@ -102,11 +102,11 @@ public class EnumWrapper<E extends Enum<E>> {
         try {
             if (getterMethod != null) {
                 return getterMethod.invoke(object);
-            } else if(property != null){
+            } else if (property != null) {
                 return property.get(object);
             } else {
                 //noinspection unchecked
-                return ((E)object).name();
+                return ((E) object).name();
             }
         } catch (Exception e) {
             throw FlexExceptions.wrap(e);

--- a/mybatis-flex-test/mybatis-flex-native-test/src/main/java/com/mybatisflex/test/IBaseEnum.java
+++ b/mybatis-flex-test/mybatis-flex-native-test/src/main/java/com/mybatisflex/test/IBaseEnum.java
@@ -1,0 +1,8 @@
+package com.mybatisflex.test;
+
+import com.mybatisflex.annotation.EnumValue;
+
+public interface IBaseEnum {
+    @EnumValue
+    int getCode();
+}

--- a/mybatis-flex-test/mybatis-flex-native-test/src/main/java/com/mybatisflex/test/SexEnum.java
+++ b/mybatis-flex-test/mybatis-flex-native-test/src/main/java/com/mybatisflex/test/SexEnum.java
@@ -18,7 +18,7 @@ package com.mybatisflex.test;
 
 import com.mybatisflex.annotation.EnumValue;
 
-public enum SexEnum {
+public enum SexEnum implements IBaseEnum{
     TYPE1(0, "女"),
     TYPE2(1, "男"),
     TYPE3(2, "未知"),
@@ -35,7 +35,7 @@ public enum SexEnum {
         this.desc = desc;
     }
 
-    @EnumValue
+//    @EnumValue
     public int getCode() {
         return code;
     }


### PR DESCRIPTION
修复 #377 仅在接口的方法上使用@EnumValue在[CompositeEnumTypeHandler.java](https://github.com/mybatis-flex/mybatis-flex/blob/main/mybatis-flex-core/src/main/java/com/mybatisflex/core/handler/CompositeEnumTypeHandler.java#L42) 
```java
List<Method> enumDbValueMethods = ClassUtil.getAllMethods(enumClass, m -> m.getAnnotation(EnumValue.class) != null);
```
无法获取到注解信息导致使用的TypeHandler委托为EnumTypeHandler而非FlexEnumTypeHandler
