### PR TITLE
feat: 为Spring的ServiceImpl#getMapper返回具体的约束泛型类型

### DIFF
--- a/mybatis-flex-spring/src/main/java/com/mybatisflex/spring/service/impl/ServiceImpl.java
+++ b/mybatis-flex-spring/src/main/java/com/mybatisflex/spring/service/impl/ServiceImpl.java
@@ -34,7 +34,7 @@ public class ServiceImpl<M extends BaseMapper<T>, T> implements IService<T> {
     protected M mapper;
 
     @Override
-    public BaseMapper<T> getMapper() {
+    public M getMapper() {
         return mapper;
     }
 


### PR DESCRIPTION
原实现返回BaseMapper<T>，仅仅包含BaseMapper的方法实际应该是该Mapper接口实际的类型，不然就需要在业务Service接口中重写getMapper() 使其返回具体的Mapper类型
```java

//  修改前
 @Override
    public BaseMapper<T> getMapper() {
        return mapper;
    }
//  修改后
    @Override
    public M getMapper() {
        return mapper;
    }


```