### PR TITLE
Fixing flaky tests in LambdaSQLTest.java

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfoFactory.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfoFactory.java
@@ -71,6 +71,7 @@ import java.time.chrono.JapaneseDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -316,6 +317,7 @@ public class TableInfoFactory {
         Set<String> defaultQueryColumns = new LinkedHashSet<>();
 
         List<Field> entityFields = getColumnFields(entityClass);
+        Collections.sort(entityFields, (field1, field2) -> field1.getName().compareTo(field2.getName()));
 
         FlexGlobalConfig config = FlexGlobalConfig.getDefaultConfig();
 

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/LambdaSqlTest.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/LambdaSqlTest.java
@@ -104,13 +104,13 @@ public class LambdaSqlTest {
 
         printSQL(queryWrapper);
         assertEquals("SELECT\n" +
-            "  ` ac `.` id `,\n" +
-            "  ` ac `.` user_name `,\n" +
-            "  ` ac `.` birthday `,\n" +
-            "  ` ac `.` sex `,\n" +
             "  ` ac `.` age `,\n" +
-            "  ` ac `.` is_normal `,\n" +
+            "  ` ac `.` birthday `,\n" +
+            "  ` ac `.` id `,\n" +
             "  ` ac `.` is_delete `,\n" +
+            "  ` ac `.` is_normal `,\n" +
+            "  ` ac `.` sex `,\n" +
+            "  ` ac `.` user_name `,\n" +
             "  ` ar `.` title `,\n" +
             "  ` ar `.` content `\n" +
             "FROM\n" +
@@ -131,13 +131,13 @@ public class LambdaSqlTest {
 
         printSQL(queryWrapper);
         assertEquals("SELECT\n" +
-            "  ` ac `.` id `,\n" +
-            "  ` ac `.` user_name `,\n" +
-            "  ` ac `.` birthday `,\n" +
-            "  ` ac `.` sex `,\n" +
             "  ` ac `.` age `,\n" +
-            "  ` ac `.` is_normal `,\n" +
+            "  ` ac `.` birthday `,\n" +
+            "  ` ac `.` id `,\n" +
             "  ` ac `.` is_delete `,\n" +
+            "  ` ac `.` is_normal `,\n" +
+            "  ` ac `.` sex `,\n" +
+            "  ` ac `.` user_name `,\n" +
             "  ` ar `.*\n" +
             "FROM\n" +
             "  ` tb_account ` AS ` ac `\n" +


### PR DESCRIPTION
This test fixes flakiness in the following tests in `com.mybatisflex.coretest.LambdaSqlTest`

1. [`com.mybatisflex.coretest.LambdaSqlTest#test04`](https://github.com/mybatis-flex/mybatis-flex/blob/fd81f4aeb88df3e708d96e31a380cb4bcd092760/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/LambdaSqlTest.java#L96)
2. [`com.mybatisflex.coretest.LambdaSqlTest#test05`](https://github.com/mybatis-flex/mybatis-flex/blob/fd81f4aeb88df3e708d96e31a380cb4bcd092760/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/LambdaSqlTest.java#L124)

When run using the [`Nondex`](https://github.com/TestingResearchIllinois/NonDex) plugin, these tests fail with the following error - 

```
[ERROR]   LambdaSqlTest.test05:133 expected:<SELECT
  ` ac `.` [id `,
  ` ac `.` user_name `,
  ` ac `.` birthday `,
  ` ac `.` sex `,
  ` ac `.` age `,
  ` ac `.` is_normal `,
  ` ac `.` is_delete] `,
  ` ar `.*
FROM
...> but was:<SELECT
  ` ac `.` [birthday `,
  ` ac `.` age `,
  ` ac `.` id `,
  ` ac `.` sex `,
  ` ac `.` user_name `,
  ` ac `.` is_delete `,
  ` ac `.` is_normal] `,
  ` ar `.*
FROM
...>
```

The root cause of this is because in code that fetches default columns for a provided class - [com.mybatisflex.core.query.QueryMethods#defaultColumns](https://github.com/mybatis-flex/mybatis-flex/blob/ca2e10dd70eff85112abb3f09f0614371d770187/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/QueryMethods.java#L2489), uses a list of column fields that internally uses java's `class.getDeclaredFields` method to fetch the appropriate list of columns - [com.mybatisflex.core.table.TableInfoFactory#getColumnFields](https://github.com/mybatis-flex/mybatis-flex/blob/b346901621acdfc50c343b843c76adce4d6d4fea/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfoFactory.java#L599). As the order of the fields in class.getDeclaredFields is not deterministic, the test is failing due to ordering issues. 

This PR fixes the test by sorting the columns after they are extracted from the class, and by refactoring the tests to check the columns in a sorted order.

After making this change, I have run the [Nondex](https://github.com/TestingResearchIllinois/NonDex) plugin over the `mybatis-flex-core` module, and have seen no impacts.

Thanks, please let me know if you have any further questions, or if any changes are required.