### PR TITLE
feat: 支持通过 Table 信息动态设置接口，支持通过设置 `generateTableStrategy` 按表名动态设置是否生成

### DIFF
--- a/docs/zh/others/codegen.md
+++ b/docs/zh/others/codegen.md
@@ -252,18 +252,19 @@ globalConfig.getPackageConfig()
 
 ## 策略配置 `StrategyConfig`
 
-| 配置                             | 描述                     | 默认值   |
-|--------------------------------|------------------------|-------|
-| setTablePrefix(String)         | 数据库表前缀，多个前缀用英文逗号（,） 隔开 | null  |
-| setLogicDeleteColumn(String)   | 逻辑删除的默认字段名称            | null  |
-| setVersionColumn(String)       | 乐观锁的字段名称               | null  |
-| setGenerateForView(boolean)    | 是否生成视图映射               | false |
-| setTableConfig(TableConfig)    | 单独为某张表添加独立的配置          | null  |
-| setColumnConfig(ColumnConfig)  | 设置某个列的全局配置             | null  |
-| setGenerateSchema(String)      | 生成哪个schema下的表          | null  |
-| setGenerateTables(String...)   | 生成哪些表，白名单              | null  |
-| setUnGenerateTables(String...) | 不生成哪些表，黑名单             | null  |
-| setIgnoreColumns(String...)    | 需要忽略的列，父类定义的字段         | null  |
+| 配置                                                  | 描述                                                                     | 默认值   |
+|-----------------------------------------------------|------------------------------------------------------------------------|-------|
+| setTablePrefix(String)                              | 数据库表前缀，多个前缀用英文逗号（,） 隔开                                                 | null  |
+| setLogicDeleteColumn(String)                        | 逻辑删除的默认字段名称                                                            | null  |
+| setVersionColumn(String)                            | 乐观锁的字段名称                                                               | null  |
+| setGenerateForView(boolean)                         | 是否生成视图映射                                                               | false |
+| setTableConfig(TableConfig)                         | 单独为某张表添加独立的配置                                                          | null  |
+| setColumnConfig(ColumnConfig)                       | 设置某个列的全局配置                                                             | null  |
+| setGenerateSchema(String)                           | 生成哪个schema下的表                                                          | null  |
+| setGenerateTables(String...)                        | 生成哪些表，白名单                                                              | null  |
+| setUnGenerateTables(String...)                      | 不生成哪些表，黑名单                                                             | null  |
+| setGenerateTableStrategy(Function<String, Boolean>) | 入参为表名，出参为是否生成，如果配置此项 `setGenerateTables` 和 `setUnGenerateTables` 将会失效 | null  |
+| setIgnoreColumns(String...)                         | 需要忽略的列，父类定义的字段                                                         | null  |
 
 ```java
 globalConfig.getStrategyConfig()
@@ -295,20 +296,21 @@ globalConfig.getTemplateConfig()
 
 ## Entity 生成配置 `EntityConfig`
 
-| 配置                                           | 描述                                                | 默认值                |
-|----------------------------------------------|---------------------------------------------------|--------------------|
-| setClassPrefix(String)                       | Entity 类的前缀                                       | ""                 |
-| setClassSuffix(String)                       | Entity 类的后缀                                       | ""                 |
-| setSuperClass(Class)                         | Entity 类的父类，可以自定义一些 BaseEntity 类                  | null               |
-| setSuperClassFactory(Function<Table, Class>) | Entity 类的父类工厂，可以用于对特定的 Class 设置父类，而非全部 Entity 的父类 | null               |
-| setOverwriteEnable(boolean)                  | 是否覆盖之前生成的文件                                       | false              |
-| setImplInterfaces(Class[])                   | Entity 默认实现的接口                                    | Serializable.class |
-| setWithLombok(boolean)                       | Entity 是否使用 Lombok 注解                             | false              |
-| setWithSwagger(boolean)                      | Entity 是否使用 Swagger 注解                            | false              |
+| 配置                                            | 描述                                                | 默认值                |
+|-----------------------------------------------|---------------------------------------------------|--------------------|
+| setClassPrefix(String)                        | Entity 类的前缀                                       | ""                 |
+| setClassSuffix(String)                        | Entity 类的后缀                                       | ""                 |
+| setSuperClass(Class)                          | Entity 类的父类，可以自定义一些 BaseEntity 类                  | null               |
+| setSuperClassFactory(Function<Table, Class>)  | Entity 类的父类工厂，可以用于对特定的 Class 设置父类，而非全部 Entity 的父类 | null               |
+| setOverwriteEnable(boolean)                   | 是否覆盖之前生成的文件                                       | false              |
+| setInterfaceFactory(Function<Table, Class>)   | Entity 类的接口工厂，可以用于对特定的 Class 设置接口，而非全部 Entity 的接口 | null               |
+| setImplInterfaces(Class[])                    | Entity 默认实现的接口                                    | Serializable.class |
+| setWithLombok(boolean)                        | Entity 是否使用 Lombok 注解                             | false              |
+| setWithSwagger(boolean)                       | Entity 是否使用 Swagger 注解                            | false              |
 | setSwaggerVersion(EntityConfig.SwaggerVersion) | Swagger 注解版本                                      | SwaggerVersion.FOX |
-| setWithActiveRecord(boolean)                 | 是否生成 Active Record 模式的 Entity                     | false              |
-| setDataSource(String)                        | 统一使用的数据源                                          | null               |
-| setJdkVersion(int)                           | 设置项目的jdk版本                                        | 0                  |
+| setWithActiveRecord(boolean)                  | 是否生成 Active Record 模式的 Entity                     | false              |
+| setDataSource(String)                         | 统一使用的数据源                                          | null               |
+| setJdkVersion(int)                            | 设置项目的jdk版本                                        | 0                  |
 
 ```java
 globalConfig.getEntityConfig()

--- a/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/config/EntityConfig.java
+++ b/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/config/EntityConfig.java
@@ -65,6 +65,8 @@ public class EntityConfig implements Serializable {
      */
     private Class<?>[] implInterfaces = {Serializable.class};
 
+    private Function<Table, Class<?>[]> interfaceFactory;
+
     /**
      * Entity 是否使用 Lombok 注解。
      */
@@ -225,6 +227,25 @@ public class EntityConfig implements Serializable {
      */
     public EntityConfig setOverwriteEnable(boolean overwriteEnable) {
         this.overwriteEnable = overwriteEnable;
+        return this;
+    }
+
+    /**
+     * 获取实现接口。
+     */
+    public Class<?>[] getInterfaces(Table table) {
+        if (interfaceFactory != null) {
+            return interfaceFactory.apply(table);
+        }
+        return implInterfaces;
+    }
+
+    public Function<Table, Class<?>[]> getInterfaceFactory() {
+        return interfaceFactory;
+    }
+
+    public EntityConfig setInterfaceFactory(Function<Table, Class<?>[]> interfaceFactory) {
+        this.interfaceFactory = interfaceFactory;
         return this;
     }
 

--- a/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/config/StrategyConfig.java
+++ b/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/config/StrategyConfig.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * 表策略配置。
@@ -79,6 +80,12 @@ public class StrategyConfig implements Serializable {
      * 需要生成的表在哪个模式下
      */
     private String generateSchema;
+
+    /**
+     * 根据表明动态判断是否可以生成
+     */
+    private Function<String, Boolean> generateTableStrategy;
+
     /**
      * 生成哪些表，白名单。
      */
@@ -225,6 +232,15 @@ public class StrategyConfig implements Serializable {
         this.columnConfigFactory = columnConfigFactory;
     }
 
+    public Function<String, Boolean> getGenerateTableStrategy() {
+        return generateTableStrategy;
+    }
+
+    public StrategyConfig setGenerateTableStrategy(Function<String, Boolean> generateTableStrategy) {
+        this.generateTableStrategy = generateTableStrategy;
+        return this;
+    }
+
     /**
      * 设置生成哪些表。
      */
@@ -263,6 +279,9 @@ public class StrategyConfig implements Serializable {
     public boolean isSupportGenerate(String table) {
         if (table == null || table.isEmpty()) {
             return true;
+        }
+        if (generateTableStrategy != null) {
+            return generateTableStrategy.apply(table);
         }
         if (unGenerateTables != null) {
             for (String unGenerateTable : unGenerateTables) {

--- a/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/entity/Table.java
+++ b/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/entity/Table.java
@@ -264,8 +264,9 @@ public class Table {
                 imports.add(superClass.getName());
             }
 
-            if (entityConfig.getImplInterfaces() != null) {
-                for (Class<?> entityInterface : entityConfig.getImplInterfaces()) {
+            Class<?>[] interfaces = entityConfig.getInterfaces(this);
+            if (interfaces != null) {
+                for (Class<?> entityInterface : interfaces) {
                     imports.add(entityInterface.getName());
                 }
             }
@@ -378,7 +379,7 @@ public class Table {
      * 构建 implements 实现。
      */
     public String buildImplements() {
-        Class<?>[] entityInterfaces = globalConfig.getEntityConfig().getImplInterfaces();
+        Class<?>[] entityInterfaces = globalConfig.getEntityConfig().getInterfaces(this);
         if (entityInterfaces != null && entityInterfaces.length > 0) {
             return " implements " + StringUtil.join(", ", Arrays.stream(entityInterfaces)
                 .map(Class::getSimpleName).collect(Collectors.toList()));
@@ -401,8 +402,8 @@ public class Table {
             name+="()";
             s.add(name);
         }
-        Class<?>[] entityInterfaces = globalConfig.getEntityConfig().getImplInterfaces();
-        if (entityInterfaces != null && entityInterfaces.length > 0) {
+        Class<?>[] entityInterfaces = globalConfig.getEntityConfig().getInterfaces(this);
+        if (entityInterfaces != null) {
             for (Class<?> inter : entityInterfaces) {
                 s.add(inter.getSimpleName());
             }


### PR DESCRIPTION
1. 与 `superClassFactory` 作用类似，可以按表名设置不同的接口
2. 当出现表名前缀重叠时，如：`s_` / `s_tp_` 可通过 `generateTableStrategy` 增强控制生成逻辑