### PR TITLE
multiple MybatisFlexBootstrap instances

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/MybatisFlexBootstrap.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/MybatisFlexBootstrap.java
@@ -133,7 +133,7 @@ public class MybatisFlexBootstrap {
      * @return mapperObject
      */
     public <T> T getMapper(Class<T> mapperClass) {
-        return Mappers.ofMapperClass(mapperClass);
+        return Mappers.ofMapperClass(getEnvironmentId(), mapperClass);
     }
 
 


### PR DESCRIPTION
修正多 MybatisFlexBootstrap 实例时调用 MybatisFlexBootstrap.getMapper(Class<T> mapperClass) 方法只能获取最后的实例的 mapper

Fixed the problem that when calling MybatisFlexBootstrap.getMapper(Class<T> mapperClass) method with multiple MybatisFlexBootstrap instances, only the mapper of the last instance can be obtained.