### PR TITLE
修正创建多个 MybatisFlexBootstrap 实例时，FlexGlobalConfig 存储的 globalConfigs 实例都是 defaultConfig 对象。

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexGlobalConfig.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexGlobalConfig.java
@@ -423,7 +423,7 @@ public class FlexGlobalConfig {
             defaultConfig.setConfiguration(config.configuration);
         }
 
-        globalConfigs.put(id, isDefault ? defaultConfig : config);
+        globalConfigs.put(id, config);
     }
 
 }


### PR DESCRIPTION
修正创建多个 MybatisFlexBootstrap 实例时，FlexGlobalConfig.getConfig(environmentId) 获取的 config 永远是 defaultConfig。

When creating multiple MybatisFlexBootstrap instances, the config obtained by FlexGlobalConfig.getConfig(environmentId) is always defaultConfig.