### PR TITLE
fix: 修复 Codegen GlobalConfig 类缺少 setEntityWithBaseClassEnable 函数问题

### DIFF
--- a/docs/zh/others/codegen.md
+++ b/docs/zh/others/codegen.md
@@ -297,6 +297,7 @@ globalConfig.getTemplateConfig()
 
 | 配置                                           | 描述                                                | 默认值                |
 |----------------------------------------------|---------------------------------------------------|--------------------|
+| setEntityWithBaseClassEnable(boolean)          | 当开启这个配置后，Entity 会生成两个类，自动生成的 getter setter 字段等都在 Base 类里，而开发者可以在 Account.java 中添加自己的业务代码  | false                 |
 | setClassPrefix(String)                       | Entity 类的前缀                                       | ""                 |
 | setClassSuffix(String)                       | Entity 类的后缀                                       | ""                 |
 | setSuperClass(Class)                         | Entity 类的父类，可以自定义一些 BaseEntity 类                  | null               |

--- a/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/config/GlobalConfig.java
+++ b/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/config/GlobalConfig.java
@@ -1035,6 +1035,20 @@ public class GlobalConfig implements Serializable {
         getEntityConfig().setJdkVersion(jdkVersion);
     }
 
+    /**
+     * @see EntityConfig#isWithBaseClassEnable()
+     */
+    public boolean isEntityWithBaseClassEnable() {
+        return getEntityConfig().isWithBaseClassEnable();
+    }
+
+    /**
+     * @see EntityConfig#setWithBaseClassEnable(boolean)
+     */
+    public void setEntityWithBaseClassEnable(boolean withBaseClassEnable) {
+        getEntityConfig().setWithBaseClassEnable(withBaseClassEnable);
+    }
+
     public boolean isMapperGenerateEnable() {
         return mapperGenerateEnable;
     }


### PR DESCRIPTION
修复 Codegen GlobalConfig 类缺少 setEntityWithBaseClassEnable 函数问题

原来只能这样设置：

```java
globalConfig.getEntityConfig().setWithBaseClassEnable(true);
```

现在可以直接

```java
globalConfig.setEntityWithBaseClassEnable(true);
```