### PR TITLE
!491 fix: QueryWrapper无法支持常量查询

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/constant/SqlConsts.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/constant/SqlConsts.java
@@ -56,6 +56,7 @@ public final class SqlConsts {
     public static final String THEN = " THEN ";
     public static final String ELSE = " ELSE ";
     public static final String FROM = " FROM ";
+    public static final String DUAL = "DUAL";
     public static final String WHERE = " WHERE ";
     public static final String SELECT = "SELECT ";
     public static final String VALUES = " VALUES ";

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/CommonsDialectImpl.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/CommonsDialectImpl.java
@@ -58,6 +58,7 @@ import static com.mybatisflex.core.constant.SqlConsts.BRACKET_RIGHT;
 import static com.mybatisflex.core.constant.SqlConsts.DELETE;
 import static com.mybatisflex.core.constant.SqlConsts.DELETE_FROM;
 import static com.mybatisflex.core.constant.SqlConsts.DELIMITER;
+import static com.mybatisflex.core.constant.SqlConsts.DUAL;
 import static com.mybatisflex.core.constant.SqlConsts.EMPTY;
 import static com.mybatisflex.core.constant.SqlConsts.EQUALS;
 import static com.mybatisflex.core.constant.SqlConsts.EQUALS_PLACEHOLDER;
@@ -102,7 +103,8 @@ public class CommonsDialectImpl implements IDialect {
 
     @Override
     public String wrap(String keyword) {
-        return ASTERISK.equals(keyword) ? keyword : keywordWrap.wrap(keyword);
+        return ASTERISK.equals(keyword) || DUAL.equalsIgnoreCase(StringUtil.tryTrim(keyword)) ?
+            keyword : keywordWrap.wrap(keyword);
     }
 
     @Override
@@ -438,7 +440,9 @@ public class CommonsDialectImpl implements IDialect {
         buildSelectColumnSql(sqlBuilder, allTables, selectColumns, CPI.getHint(queryWrapper));
 
 
-        sqlBuilder.append(FROM).append(StringUtil.join(DELIMITER, queryTables, queryTable -> queryTable.toSql(this, OperateType.SELECT)));
+        if(CollectionUtil.isNotEmpty(queryTables)) {
+            sqlBuilder.append(FROM).append(StringUtil.join(DELIMITER, queryTables, queryTable -> queryTable.toSql(this, OperateType.SELECT)));
+        }
 
         buildJoinSql(sqlBuilder, queryWrapper, allTables, OperateType.SELECT);
         buildWhereSql(sqlBuilder, queryWrapper, allTables, true);

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/QueryWrapperTest.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/QueryWrapperTest.java
@@ -80,4 +80,34 @@ public class QueryWrapperTest {
         Assert.assertEquals(CPI.getValueArray(wrapper).length, 3);
     }
 
+    /**
+     * https://github.com/mybatis-flex/mybatis-flex/issues/491
+     */
+    @Test
+    public void testIssues491() {
+        String demo1 = "SELECT c1 FROM ((SELECT 1 as c1) UNION ALL (SELECT 2 as c1) UNION ALL (SELECT 3 as c1)) AS `t`";
+
+        QueryWrapper query1 = QueryWrapper.create()
+            .select("c1")
+            .from(QueryWrapper.create().select("1 as c1")
+                .unionAll(QueryWrapper.create().select("2 as c1"))
+                .unionAll(QueryWrapper.create().select("3 as c1")))
+            .as("t");
+
+       Assert.assertTrue(query1.toSQL().equals(demo1));
+
+
+        String demo2 = "SELECT c1 FROM ((SELECT 1 as c1 FROM dual) UNION ALL (SELECT 2 as c1 FROM dual) UNION ALL " +
+            "(SELECT 3 as c1 FROM dual)) AS `t`";
+
+        QueryWrapper query2 = QueryWrapper.create()
+            .select("c1")
+            .from(QueryWrapper.create().select("1 as c1").from("dual")
+                .unionAll(QueryWrapper.create().select("2 as c1").from("dual"))
+                .unionAll(QueryWrapper.create().select("3 as c1").from("dual")))
+            .as("t");
+
+        Assert.assertTrue(query2.toSQL().equals(demo2));
+    }
+
 }


### PR DESCRIPTION
[Issue-491: ](https://github.com/mybatis-flex/mybatis-flex/issues/491)

### 对CommonsDialectImpl增加两个特性：

1. buildSelectSql方法，queryTables为空时，不拼接FROM关键词
2. wrap方法，如果keyword是"DUAL"关键词，直接输出原始内容