### PR TITLE
fix: exists 条件中的表别名和父查询保持一致

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/IDialect.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/IDialect.java
@@ -15,6 +15,7 @@
  */
 package com.mybatisflex.core.dialect;
 
+import com.mybatisflex.core.query.QueryTable;
 import com.mybatisflex.core.query.QueryWrapper;
 import com.mybatisflex.core.row.Row;
 import com.mybatisflex.core.table.TableInfo;
@@ -63,6 +64,10 @@ public interface IDialect {
     String forSelectByQuery(QueryWrapper queryWrapper);
 
     String buildSelectSql(QueryWrapper queryWrapper);
+
+    default String buildSelectSql(QueryWrapper queryWrapper, List<QueryTable> contextTables) {
+        return buildSelectSql(queryWrapper);
+    }
 
     String buildNoSelectSql(QueryWrapper queryWrapper);
 

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/CommonsDialectImpl.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/CommonsDialectImpl.java
@@ -395,10 +395,16 @@ public class CommonsDialectImpl implements IDialect {
     ////////////build query sql///////
     @Override
     public String buildSelectSql(QueryWrapper queryWrapper) {
+        return buildSelectSql(queryWrapper, Collections.emptyList());
+    }
+
+    @Override
+    public String buildSelectSql(QueryWrapper queryWrapper, List<QueryTable> contextTables) {
         List<QueryTable> queryTables = CPI.getQueryTables(queryWrapper);
 
         List<QueryTable> joinTables = CPI.getJoinTables(queryWrapper);
         List<QueryTable> allTables = CollectionUtil.merge(queryTables, joinTables);
+        allTables = CollectionUtil.merge(allTables, contextTables);
 
         List<QueryColumn> selectColumns = CPI.getSelectColumns(queryWrapper);
 

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/OperatorSelectCondition.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/OperatorSelectCondition.java
@@ -48,7 +48,7 @@ public class OperatorSelectCondition extends QueryCondition {
 
         //检测是否生效
         if (checkEffective()) {
-            String childSql = dialect.buildSelectSql(queryWrapper);
+            String childSql = dialect.buildSelectSql(queryWrapper, queryTables);
             if (StringUtil.hasText(childSql)) {
                 QueryCondition prevEffectiveCondition = getPrevEffectiveCondition();
                 if (prevEffectiveCondition != null && this.connector != null) {

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/AccountSqlTester.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/AccountSqlTester.java
@@ -400,7 +400,7 @@ public class AccountSqlTester {
 
         Assert.assertEquals("SELECT * FROM `tb_account` " +
                 "WHERE `id` >= 100 " +
-                "AND EXISTS (SELECT 1 AS `temp_one` FROM `tb_article` AS `a` WHERE `id` >= 100)"
+                "AND EXISTS (SELECT 1 AS `temp_one` FROM `tb_article` AS `a` WHERE `a`.`id` >= 100)"
             , query.toSQL());
 
         System.out.println(query.toSQL());


### PR DESCRIPTION
#442 
项目中遇到了类似的问题，扩展 buildSelectSql() 实现别名传递
子查询的别名是不是也可以这样处理？