### PR TITLE
feat: 对于用户常用类，启用代码折叠支持

### DIFF
--- a/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/config/GlobalConfig.java
+++ b/mybatis-flex-codegen/src/main/java/com/mybatisflex/codegen/config/GlobalConfig.java
@@ -42,7 +42,7 @@ public class GlobalConfig implements Serializable {
 
     private final FileType fileType;
 
-    // === 必须配置 ===
+    //region === 必须配置 ===
 
     public GlobalConfig() {
         this(FileType.JAVA);
@@ -52,8 +52,9 @@ public class GlobalConfig implements Serializable {
     private final PackageConfig packageConfig;
     private final StrategyConfig strategyConfig;
     private final TemplateConfig templateConfig;
+    //endregion === 必须配置 ===
 
-    // === 可选配置 ===
+    //region === 可选配置 ===
 
     private EntityConfig entityConfig;
     private MapperConfig mapperConfig;
@@ -62,11 +63,13 @@ public class GlobalConfig implements Serializable {
     private ControllerConfig controllerConfig;
     private TableDefConfig tableDefConfig;
     private MapperXmlConfig mapperXmlConfig;
+    //endregion === 可选配置 ===
 
-    // === 其他自定义配置 ===
+    //region === 其他自定义配置 ===
     private Map<String, Object> customConfig = new HashMap<>();
+    //endregion === 其他自定义配置 ===
 
-    // === 是否启用生成 ===
+    //region === 是否启用生成 ===
 
     private boolean entityGenerateEnable;
     private boolean mapperGenerateEnable;
@@ -122,8 +125,9 @@ public class GlobalConfig implements Serializable {
         }
 
     }
+    //endregion === 是否启用生成 ===
 
-    // === 分类配置 ===
+    //region === 分类配置 ===
 
     public JavadocConfig getJavadocConfig() {
         return javadocConfig;
@@ -189,8 +193,9 @@ public class GlobalConfig implements Serializable {
         }
         return mapperXmlConfig;
     }
+    //endregion === 分类配置 ===
 
-    // === 启用配置 ===
+    //region === 启用配置 ===
 
     public EntityConfig enableEntity() {
         entityGenerateEnable = true;
@@ -230,8 +235,9 @@ public class GlobalConfig implements Serializable {
     public void enablePackageInfo() {
         packageInfoGenerateEnable = true;
     }
+    //endregion === 启用配置 ===
 
-    // === 禁用配置 ===
+    //region === 禁用配置 ===
 
     public void disableEntity() {
         entityGenerateEnable = false;
@@ -264,9 +270,9 @@ public class GlobalConfig implements Serializable {
     public void disablePackageInfo() {
         packageInfoGenerateEnable = false;
     }
+    //endregion === 禁用配置 ===
 
-
-    // === 自定义配置 ===
+    //region === 自定义配置 ===
 
     public Object getCustomConfig(String key) {
         return customConfig.get(key);
@@ -283,7 +289,9 @@ public class GlobalConfig implements Serializable {
     public void setCustomConfig(Map<String, Object> customConfig) {
         this.customConfig = customConfig;
     }
-    // === 分项配置 ===
+    //endregion === 自定义配置 ===
+
+    //region === 分项配置 ===
 
     /**
      * @see JavadocConfig#getAuthor()
@@ -1566,5 +1574,5 @@ public class GlobalConfig implements Serializable {
     public void setPackageInfoGenerateEnable(boolean packageInfoGenerateEnable) {
         this.packageInfoGenerateEnable = packageInfoGenerateEnable;
     }
-
+    //endregion === 分项配置 ===
 }

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/BaseMapper.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/BaseMapper.java
@@ -74,7 +74,7 @@ public interface BaseMapper<T> {
      */
     int DEFAULT_BATCH_SIZE = 1000;
 
-    // === 增（insert） ===
+    //region === 增（insert） ===
 
     /**
      * 插入实体类数据，不忽略 {@code null} 值。
@@ -253,8 +253,9 @@ public interface BaseMapper<T> {
             return update(entity, ignoreNulls);
         }
     }
+    //endregion === 增（insert） ===
 
-    // === 删（delete） ===
+    //region === 删（delete） ===
 
     /**
      * 根据实体主键来删除数据。
@@ -343,8 +344,9 @@ public interface BaseMapper<T> {
      */
     @DeleteProvider(type = EntitySqlProvider.class, method = "deleteByQuery")
     int deleteByQuery(@Param(FlexConsts.QUERY) QueryWrapper queryWrapper);
+    //endregion === 删（delete） ===
 
-    // === 改（update） ===
+    //region === 改（update） ===
 
     /**
      * 根据主键来更新数据，若实体类属性数据为 {@code null}，该属性不会更新到数据库。
@@ -439,9 +441,9 @@ public interface BaseMapper<T> {
      */
     @UpdateProvider(type = EntitySqlProvider.class, method = "updateByQuery")
     int updateByQuery(@Param(FlexConsts.ENTITY) T entity, @Param(FlexConsts.IGNORE_NULLS) boolean ignoreNulls, @Param(FlexConsts.QUERY) QueryWrapper queryWrapper);
+    //endregion === 改（update） ===
 
-
-    // === 查（select） ===
+    //region === 改（update） ===
 
     /**
      * 根据实体主键查询数据。
@@ -1264,5 +1266,5 @@ public interface BaseMapper<T> {
         }
         return page;
     }
-
+    //endregion === 改（update） ===
 }

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/QueryMethods.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/QueryMethods.java
@@ -35,7 +35,7 @@ public class QueryMethods {
     private QueryMethods() {
     }
 
-    // === 数学函数 ===
+    //region === 数学函数 ===
 
     /**
      * 返回 x 的绝对值。
@@ -680,8 +680,9 @@ public class QueryMethods {
     public static <T> QueryColumn cot(LambdaGetter<T> columnX) {
         return new FunctionQueryColumn(COT, LambdaUtil.getQueryColumn(columnX));
     }
+    //endregion === 数学函数 ===
 
-    // === 字符串函数 ===
+    //region === 字符串函数 ===
 
     /**
      * 返回字符串 s 的字符数。
@@ -1181,8 +1182,9 @@ public class QueryMethods {
     public static <S1, S2> QueryColumn findInSet(LambdaGetter<S1> columnS1, LambdaGetter<S2> columnS2) {
         return new FunctionQueryColumn(FIND_IN_SET, LambdaUtil.getQueryColumn(columnS1), LambdaUtil.getQueryColumn(columnS2));
     }
+    //endregion === 字符串函数 ===
 
-    // === 日期时间函数 ===
+    //region === 日期时间函数 ===
 
     /**
      * 返回当前日期。
@@ -1884,8 +1886,9 @@ public class QueryMethods {
     public static <T, S> QueryColumn getFormat(LambdaGetter<T> columnType, LambdaGetter<S> columnS) {
         return new FunctionQueryColumn(GET_FORMAT, LambdaUtil.getQueryColumn(columnType), LambdaUtil.getQueryColumn(columnS));
     }
+    //endregion === 日期时间函数 ===
 
-    // === 系统信息函数 ===
+    //region === 系统信息函数 ===
 
     /**
      * 返回数据库的版本号。
@@ -1970,8 +1973,9 @@ public class QueryMethods {
     public static QueryColumn lastInsertId() {
         return new FunctionQueryColumn(LAST_INSERT_ID);
     }
+    //endregion === 系统信息函数 ===
 
-    // === 加密函数 ===
+    //region === 加密函数 ===
 
     /**
      * 对字符串 str 进行加密。
@@ -2056,8 +2060,9 @@ public class QueryMethods {
     public static <C, P> QueryColumn decode(LambdaGetter<C> columnCryptStr, LambdaGetter<P> columnPswdStr) {
         return new FunctionQueryColumn(DECODE, LambdaUtil.getQueryColumn(columnCryptStr), LambdaUtil.getQueryColumn(columnPswdStr));
     }
+    //endregion === 加密函数 ===
 
-    // === 其他函数 ===
+    //region === 其他函数 ===
 
     /**
      * 格式化函数，可以将数字 x 进行格式化，将 x 保留到小数点后 n 位，这个过程需要进行四舍五入。
@@ -2226,8 +2231,9 @@ public class QueryMethods {
     public static <T> QueryColumn inetNtoa(LambdaGetter<T> columnN) {
         return new FunctionQueryColumn(INET_NTOA, LambdaUtil.getQueryColumn(columnN));
     }
+    //endregion === 其他函数 ===
 
-    // === 聚合函数 ===
+    //region === 聚合函数 ===
 
     /**
      * 返回指定列的最大值。
@@ -2312,8 +2318,9 @@ public class QueryMethods {
     public static <T> FunctionQueryColumn sum(LambdaGetter<T> column) {
         return new FunctionQueryColumn(SUM, LambdaUtil.getQueryColumn(column));
     }
+    //endregion === 聚合函数 ===
 
-    // === COUNT ===
+    //region === COUNT ===
 
     /**
      * 返回指定列的总行数。
@@ -2342,9 +2349,9 @@ public class QueryMethods {
     public static <T> FunctionQueryColumn count(LambdaGetter<T> column) {
         return new FunctionQueryColumn(COUNT, LambdaUtil.getQueryColumn(column));
     }
+    //endregion === COUNT ===
 
-
-    // === DISTINCT ===
+    //region === DISTINCT ===
 
     /**
      * 对指定列进行去重。
@@ -2358,8 +2365,9 @@ public class QueryMethods {
         return new DistinctQueryColumn(Arrays.stream(columns)
             .map(LambdaUtil::getQueryColumn).toArray(QueryColumn[]::new));
     }
+    //endregion === DISTINCT ===
 
-    // === CASE THEN ELSE ===
+    //region === CASE THEN ELSE ===
 
     /**
      * 构建 case then when 语句。
@@ -2374,8 +2382,9 @@ public class QueryMethods {
     public static CaseSearchQueryColumn.Builder case_(QueryColumn column) {
         return new CaseSearchQueryColumn.Builder(column);
     }
+    //endregion === CASE THEN ELSE ===
 
-    // === CONVERT ===
+    //region === CONVERT ===
 
     /**
      * 将所给类型类型转换为另一种类型。
@@ -2383,8 +2392,9 @@ public class QueryMethods {
     public static StringFunctionQueryColumn convert(String... params) {
         return new StringFunctionQueryColumn(CONVERT, params);
     }
+    //endregion === CONVERT ===
 
-    // === 构建 column 列 ===
+    //region === 构建 column 列 ===
 
     /**
      * 构建 TRUE 常量。
@@ -2494,8 +2504,9 @@ public class QueryMethods {
         }
         return queryColumns;
     }
+    //endregion === 构建 column 列 ===
 
-    // === IF 函数 ===
+    //region === IF 函数 ===
 
     /**
      * IF 函数。
@@ -2552,9 +2563,9 @@ public class QueryMethods {
     public static <N> QueryColumn ifNull(LambdaGetter<N> nullColumn, String elseColumn) {
         return ifNull(nullColumn, new QueryColumn(elseColumn));
     }
+    //endregion === IF 函数 ===
 
-
-    // === 构建 QueryCondition 查询条件 ===
+    //region === 构建 QueryCondition 查询条件 ===
 
     /**
      * EXIST (SELECT ...)
@@ -2597,8 +2608,9 @@ public class QueryMethods {
     public static QueryCondition bracket(QueryCondition condition) {
         return new Brackets(condition);
     }
+    //endregion === 构建 QueryCondition 查询条件 ===
 
-    // === 构建 QueryWrapper 查询 ===
+    //region === 构建 QueryWrapper 查询 ===
 
     /**
      * SELECT queryColumns FROM table
@@ -2673,5 +2685,5 @@ public class QueryMethods {
     public static FunctionQueryColumn date(QueryColumn column) {
         return new FunctionQueryColumn("DATE", column);
     }
-
+    //endregion === 构建 QueryWrapper 查询 ===
 }

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/service/IService.java
@@ -51,7 +51,7 @@ public interface IService<T> {
      */
     BaseMapper<T> getMapper();
 
-    // ===== 保存（增）操作 =====
+    //region ===== 保存（增）操作 =====
 
     /**
      * <p>保存实体类对象数据。
@@ -128,8 +128,9 @@ public interface IService<T> {
         Class<BaseMapper<T>> usefulClass = (Class<BaseMapper<T>>) ClassUtil.getUsefulClass(getMapper().getClass());
         return SqlUtil.toBool(Db.executeBatch(entities, batchSize, usefulClass, BaseMapper::insertOrUpdateSelective));
     }
+    //endregion ===== 保存（增）操作 =====
 
-    // ===== 删除（删）操作 =====
+    //region ===== 删除（删）操作 =====
 
     /**
      * <p>根据查询条件删除数据。
@@ -197,8 +198,9 @@ public interface IService<T> {
         }
         return remove(query().where(query));
     }
+    //endregion ===== 删除（删）操作 =====
 
-    // ===== 更新（改）操作 =====
+    //region ===== 更新（改）操作 =====
 
     /**
      * <p>根据数据主键更新数据。
@@ -313,8 +315,9 @@ public interface IService<T> {
         Class<BaseMapper<T>> usefulClass = (Class<BaseMapper<T>>) ClassUtil.getUsefulClass(getMapper().getClass());
         return SqlUtil.toBool(Db.executeBatch(entities, batchSize, usefulClass, (mapper, entity) -> mapper.update(entity, ignoreNulls)));
     }
+    //endregion ===== 更新（改）操作 =====
 
-    // ===== 查询（查）操作 =====
+    //region ===== 查询（查）操作 =====
 
     /**
      * <p>根据数据主键查询一条数据。
@@ -546,8 +549,9 @@ public interface IService<T> {
     default List<T> listByMap(Map<String, Object> query) {
         return list(query().where(query));
     }
+    //endregion ===== 查询（查）操作 =====
 
-    // ===== 数量查询操作 =====
+    //region ===== 数量查询操作 =====
 
     /**
      * <p>根据查询条件判断数据是否存在。
@@ -605,8 +609,9 @@ public interface IService<T> {
     default long count(QueryCondition condition) {
         return count(query().where(condition));
     }
+    //endregion ===== 数量查询操作 =====
 
-    // ===== 分页查询操作 =====
+    //region ===== 分页查询操作 =====
 
     /**
      * <p>分页查询所有数据。
@@ -651,8 +656,9 @@ public interface IService<T> {
     default <R> Page<R> pageAs(Page<R> page, QueryWrapper query, Class<R> asType) {
         return getMapper().paginateAs(page, query, asType);
     }
+    //endregion ===== 分页查询操作 =====
 
-    // ===== 查询包装器操作 =====
+    //region ===== 查询包装器操作 =====
 
     /**
      * 默认 {@link QueryWrapper} 构建。
@@ -680,5 +686,5 @@ public interface IService<T> {
     default UpdateChain<T> updateChain() {
         return UpdateChain.create(getMapper());
     }
-
+    //endregion ===== 查询包装器操作 =====
 }


### PR DESCRIPTION
对于`BaseMapper`、`IService`这几个类启用代码折抵支持，目前官方已经进行了分组，但没有使用代码折叠。
添加后代码效果：
![image](https://github.com/user-attachments/assets/db54f997-34de-4fbf-a2c4-ee1d36c055a9)
