### PR TITLE
fix: -m core 修复自动关联查询功能：表信息查找逻辑调整

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/AbstractRelation.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/relation/AbstractRelation.java
@@ -86,8 +86,9 @@ public abstract class AbstractRelation<SelfEntity> {
         this.selfField = ClassUtil.getFirstField(entityClass, field -> field.getName().equalsIgnoreCase(selfField));
         this.selfFieldWrapper = FieldWrapper.of(entityClass, selfField);
 
+        String tableNameWithSchema = StringUtil.buildSchemaWithTable(targetSchema, targetTable);
         //以使用者注解配置为主
-        this.targetTableInfo = StringUtil.noText(targetTable) ? TableInfoFactory.ofEntityClass(relationFieldWrapper.getMappingType()) : TableInfoFactory.ofTableName(targetTable);
+        this.targetTableInfo = StringUtil.noText(targetTable) ? TableInfoFactory.ofEntityClass(relationFieldWrapper.getMappingType()) : TableInfoFactory.ofTableName(tableNameWithSchema);
         this.targetSchema = targetTableInfo != null ? targetTableInfo.getSchema() : targetSchema;
         this.targetTable = targetTableInfo != null ? targetTableInfo.getTableName() : targetTable;
 


### PR DESCRIPTION
一对多关联配置：（当表的实体配置了 schema 时，使用 valueField = "name" 字段会解析失败）
```
    @RelationOneToMany(
        selfField = "diseaseIds",
        selfValueSplitBy = ",", //使用 "," 对 diseaseIds 的值进行分割
        targetTable = "tb_disease", //只获取某个字段值需要填入目标表名
        targetField = "diseaseId", //测试目标字段是字符串类型是否正常转换
        valueField = "name" //测试只获取某个字段值是否正常
    )
    private List<String> diseaseNameList;
```
`TableInfoFactory` 中设置表信息缓存的逻辑是使用 `tableInfo.getTableNameWithSchema()`，而关联查询在查找表信息的使用，使用的是不带 Shema 的表名，从而导致查询结果为 null

```java
    // TableInfoFactory.class
    public static TableInfo ofEntityClass(Class<?> entityClass) {
        return MapUtil.computeIfAbsent(entityTableMap, entityClass, aClass -> {
            TableInfo tableInfo = createTableInfo(entityClass);
            // Entity 和 VO 有相同的表名，以第一次放入的 Entity 解析的 TableInfo 为主
            tableInfoMap.putIfAbsent(tableInfo.getTableNameWithSchema(), tableInfo);
            return tableInfo;
        });
    }
```
关键代码：
```java
this.targetTableInfo = StringUtil.noText(targetTable) 
? TableInfoFactory.ofEntityClass(relationFieldWrapper.getMappingType()) 
// 这里使用了不带 Schema 的表名进行查询，导致找不到表信息（TableInfoFactory 中的表信息是带 Shema 的）
: TableInfoFactory.ofTableName(targetTable);

```
<img width="1215" height="630" alt="image" src="https://github.com/user-attachments/assets/d9184816-e576-4634-bdf4-8a04da882a9f" />
