### PR TITLE
RawQueryColumn中生成sql文时，使用dialect.wrap(content)处理

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/RawQueryColumn.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/RawQueryColumn.java
@@ -15,7 +15,6 @@
  */
 package com.mybatisflex.core.query;
 
-
 import com.mybatisflex.core.dialect.IDialect;
 
 import java.util.Arrays;
@@ -39,20 +38,20 @@ public class RawQueryColumn extends QueryColumn implements HasParamsColumn {
 
     @Override
     protected String toConditionSql(List<QueryTable> queryTables, IDialect dialect) {
-        return content;
+        return dialect.wrap(content);
     }
 
     @Override
     protected String toSelectSql(List<QueryTable> queryTables, IDialect dialect) {
-        return content + WrapperUtil.buildColumnAlias(alias, dialect);
+        return dialect.wrap(content) + WrapperUtil.buildColumnAlias(alias, dialect);
     }
 
     @Override
     public String toString() {
         return "RawQueryColumn{" +
-            "content='" + content + '\'' +
-            ", params='" + Arrays.toString(params) + '\'' +
-            '}';
+                "content='" + content + '\'' +
+                ", params='" + Arrays.toString(params) + '\'' +
+                '}';
     }
 
     public String getContent() {

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/ArticleSqlTester.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/ArticleSqlTester.java
@@ -27,15 +27,15 @@ import org.junit.Test;
 import static com.mybatisflex.coretest.table.ArticleTableDef.ARTICLE;
 import static org.junit.Assert.assertEquals;
 
+import javax.management.Query;
 
 public class ArticleSqlTester {
-
 
     @Test
     public void testSelectSql() {
         QueryWrapper query = new QueryWrapper()
-            .select()
-            .from(ARTICLE);
+                .select()
+                .from(ARTICLE);
 
         IDialect dialect = new CommonsDialectImpl();
         String sql = dialect.forSelectByQuery(query);
@@ -53,10 +53,12 @@ public class ArticleSqlTester {
         TableInfo tableInfo = TableInfoFactory.ofEntityClass(Article.class);
         String sql = dialect.forInsertEntity(tableInfo, article, false);
         System.out.println(sql);
-        assertEquals("INSERT INTO `tb_article`(`uuid`, `account_id`, `title`, `content`, `created`, `modified`, `is_delete`, `version`) " +
-            "VALUES (?, ?, ?, ?, now(), now(), ?, ?)", sql);
+        assertEquals(
+                "INSERT INTO `tb_article`(`uuid`, `account_id`, `title`, `content`, `created`, `modified`, `is_delete`, `version`) "
+                        +
+                        "VALUES (?, ?, ?, ?, now(), now(), ?, ?)",
+                sql);
     }
-
 
     @Test
     public void testInsert1Sql() {
@@ -68,9 +70,10 @@ public class ArticleSqlTester {
         TableInfo tableInfo = TableInfoFactory.ofEntityClass(Article.class);
         String sql = dialect.forInsertEntity(tableInfo, article, true);
         System.out.println(sql);
-        assertEquals("INSERT INTO `tb_article`(`account_id`, `content`, `created`, `modified`) VALUES (?, ?, now(), now())", sql);
+        assertEquals(
+                "INSERT INTO `tb_article`(`account_id`, `content`, `created`, `modified`) VALUES (?, ?, now(), now())",
+                sql);
     }
-
 
     @Test
     public void testInsertBatchSql() {
@@ -86,10 +89,12 @@ public class ArticleSqlTester {
         TableInfo tableInfo = TableInfoFactory.ofEntityClass(Article.class);
         String sql = dialect.forInsertEntityBatch(tableInfo, CollectionUtil.newArrayList(article1, article2));
         System.out.println(sql);
-        assertEquals("INSERT INTO `tb_article`(`uuid`, `account_id`, `title`, `content`, `created`, `modified`, `is_delete`, `version`) " +
-            "VALUES (?, ?, ?, ?, now(), now(), ?, ?), (?, ?, ?, ?, now(), now(), ?, ?)", sql);
+        assertEquals(
+                "INSERT INTO `tb_article`(`uuid`, `account_id`, `title`, `content`, `created`, `modified`, `is_delete`, `version`) "
+                        +
+                        "VALUES (?, ?, ?, ?, now(), now(), ?, ?), (?, ?, ?, ?, now(), now(), ?, ?)",
+                sql);
     }
-
 
     @Test
     public void testDeleteSql() {
@@ -97,19 +102,19 @@ public class ArticleSqlTester {
         TableInfo tableInfo = TableInfoFactory.ofEntityClass(Article.class);
         String sql = dialect.forDeleteEntityById(tableInfo);
         System.out.println(sql);
-        assertEquals("UPDATE `tb_article` SET `is_delete` = 1 WHERE `id` = ?  AND `uuid` = ?  AND `is_delete` = 0", sql);
+        assertEquals("UPDATE `tb_article` SET `is_delete` = 1 WHERE `id` = ?  AND `uuid` = ?  AND `is_delete` = 0",
+                sql);
     }
-
 
     @Test
     public void testDeleteByIdsSql() {
         IDialect dialect = new CommonsDialectImpl();
         TableInfo tableInfo = TableInfoFactory.ofEntityClass(Article.class);
-        String sql = dialect.forDeleteEntityBatchByIds(tableInfo, new Object[]{1, 2, 3});
+        String sql = dialect.forDeleteEntityBatchByIds(tableInfo, new Object[] { 1, 2, 3 });
         System.out.println(sql);
-        assertEquals("UPDATE `tb_article` SET `is_delete` = 1 WHERE ((`id` = ?  AND `uuid` = ? )) AND `is_delete` = 0", sql);
+        assertEquals("UPDATE `tb_article` SET `is_delete` = 1 WHERE ((`id` = ?  AND `uuid` = ? )) AND `is_delete` = 0",
+                sql);
     }
-
 
     @Test
     public void testUpdateSql() {
@@ -123,10 +128,9 @@ public class ArticleSqlTester {
         String sql = dialect.forUpdateEntity(tableInfo, article, true);
         System.out.println(sql);
         assertEquals("UPDATE `tb_article` " +
-            "SET `account_id` = ? , `content` = ? , `modified` = now(), `version` = `version` + 1  " +
-            "WHERE `id` = ?  AND `uuid` = ?  AND `is_delete` = 0 AND `version` = 1", sql);
+                "SET `account_id` = ? , `content` = ? , `modified` = now(), `version` = `version` + 1  " +
+                "WHERE `id` = ?  AND `uuid` = ?  AND `is_delete` = 0 AND `version` = 1", sql);
     }
-
 
     @Test
     public void testUpdateByQuerySql() {
@@ -136,13 +140,30 @@ public class ArticleSqlTester {
         article.setVersion(1L);
 
         QueryWrapper queryWrapper = new QueryWrapper()
-            .where(ARTICLE.ID.ge(100));
+                .where(ARTICLE.ID.ge(100));
 
         IDialect dialect = new CommonsDialectImpl();
         TableInfo tableInfo = TableInfoFactory.ofEntityClass(Article.class);
         String sql = dialect.forUpdateEntityByQuery(tableInfo, article, true, queryWrapper);
         System.out.println(sql);
-        assertEquals("UPDATE `tb_article` SET `account_id` = ? , `content` = ? , `modified` = now(), `version` = `version` + 1  WHERE `id` >= ?", sql);
+        assertEquals(
+                "UPDATE `tb_article` SET `account_id` = ? , `content` = ? , `modified` = now(), `version` = `version` + 1  WHERE `id` >= ?",
+                sql);
+    }
+
+    @Test
+    public void testSelectByPlusQuerySql() {
+        QueryWrapper queryWrapper = new QueryWrapper();
+        queryWrapper.select("select");
+        queryWrapper.from("from");
+        queryWrapper.eq("select", 1);
+        queryWrapper.orderBy("order", true);
+        IDialect dialect = new CommonsDialectImpl();
+        String sql = dialect.forSelectByQuery(queryWrapper);
+        System.out.println(sql);
+        assertEquals(
+                "SELECT `select` FROM `from` WHERE `select` = ? ORDER BY `order` ASC",
+                sql);
     }
 
 }


### PR DESCRIPTION
使用关键字作为表字段时，如果使用queryWrapper.eq("select", 1);情况下，生成的sql文执行错误。
```java   
QueryWrapper queryWrapper = new QueryWrapper();
queryWrapper.select("select");
queryWrapper.from("from");
queryWrapper.eq("select", 1);
queryWrapper.orderBy("order", true);
IDialect dialect = new CommonsDialectImpl();
String sql = dialect.forSelectByQuery(queryWrapper);
```
会生成：
```sql
SELECT select FROM `from` WHERE select = ? ORDER BY order ASC
```
使用dialect.wrap(content)处理后：
```sql
SELECT `select` FROM `from` WHERE `select` = ? ORDER BY `order` ASC
```