### PR TITLE
fix: 修复EXISTS、NOT EXISTS的子select语句无法自动附加逻辑删除的问题

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/WrapperUtil.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/WrapperUtil.java
@@ -50,7 +50,12 @@ class WrapperUtil {
                     }
                 }
                 // not Brackets
-                else {
+                else if (condition instanceof OperatorSelectCondition) {
+                    if (list == null) {
+                        list = new ArrayList<>();
+                    }
+                    list.add(((OperatorSelectCondition) condition).getQueryWrapper());
+                } else {
                     Object value = condition.getValue();
                     if (value instanceof QueryWrapper) {
                         if (list == null) {


### PR DESCRIPTION
link [https://github.com/mybatis-flex/mybatis-flex/issues/398](https://github.com/mybatis-flex/mybatis-flex/issues/398)