### PR TITLE
fix 修复@EnumValue应用在接口方法且返回类型为泛型时失效的问题

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/EnumWrapper.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/EnumWrapper.java
@@ -77,13 +77,22 @@ public class EnumWrapper<E extends Enum<E>> {
                 if (!(methodName.startsWith("get") && methodName.length() > 3)) {
                     throw new IllegalStateException("Can not find get method \"" + methodName + "()\" in enum: " + enumClass.getName());
                 }
+
+                String enumValueFieldName;
+                if (methodName.startsWith("get")) {
+                    enumValueFieldName = StringUtil.firstCharToLowerCase(enumValueMethod.getName().substring(3));
+                } else {
+                    enumValueFieldName = enumValueMethod.getName().toLowerCase();
+                }
+                enumValueField = ClassUtil.getFirstField(enumClass, field -> enumValueFieldName.equals(field.getName()));
+                if (enumValueField != null) {
+                    propertyType = ClassUtil.getWrapType(enumValueField.getType());
+                } else {
+                    throw new IllegalStateException("Can not find field \"" + enumValueFieldName + "()\" in enum: " + enumClass.getName());
+                }
+
                 this.getterMethod = enumValueMethod;
                 this.hasEnumValueAnnotation = true;
-                Class<?> returnType = enumValueMethod.getReturnType();
-                if (returnType.isPrimitive()) {
-                    returnType = ConvertUtil.primitiveToBoxed(returnType);
-                }
-                this.propertyType = returnType;
             }
         }
     }


### PR DESCRIPTION
[#377 @EnumValue应用在接口方法且返回类型为泛型时失效](https://github.com/mybatis-flex/mybatis-flex/issues/377)