### PR TITLE
refactor: -m flex 调整TransactionObject访问修饰符为public

### DIFF
--- a/mybatis-flex-loveqq-starter/src/main/java/com/mybatisflex/loveqq/framework/boot/autoconfig/transaction/FlexTransactionManager.java
+++ b/mybatis-flex-loveqq-starter/src/main/java/com/mybatisflex/loveqq/framework/boot/autoconfig/transaction/FlexTransactionManager.java
@@ -91,7 +91,7 @@ public class FlexTransactionManager extends AbstractPlatformTransactionManager {
         TimeoutHolder.clear();
     }
 
-    static class TransactionObject extends JdbcTransactionObjectSupport {
+    public static class TransactionObject extends JdbcTransactionObjectSupport {
 
         private static final ThreadLocal<String> ROLLBACK_ONLY_XIDS = new ThreadLocal<>();
 

--- a/mybatis-flex-spring/src/main/java/com/mybatisflex/spring/FlexTransactionManager.java
+++ b/mybatis-flex-spring/src/main/java/com/mybatisflex/spring/FlexTransactionManager.java
@@ -91,7 +91,7 @@ public class FlexTransactionManager extends AbstractPlatformTransactionManager {
         TimeoutHolder.clear();
     }
 
-    static class TransactionObject extends JdbcTransactionObjectSupport {
+    public static class TransactionObject extends JdbcTransactionObjectSupport {
 
         private static final ThreadLocal<String> ROLLBACK_ONLY_XIDS = new ThreadLocal<>();
 


### PR DESCRIPTION
对 Spring `PlatformTransactionManager` 做事务相关监控的时候，`FlexTransactionManager` 的内部类 `TransactionObject` 设置成 `public` 供拦截器调用，能够提供更多详细的监控信息