### PR TITLE
fix: 带子查询的场景下，分页优化误删 join 的修复

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/OperatorSelectCondition.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/OperatorSelectCondition.java
@@ -76,7 +76,8 @@ public class OperatorSelectCondition extends QueryCondition {
     @Override
     boolean containsTable(String... tables) {
         QueryCondition condition = queryWrapper.getWhereQueryCondition();
-        return condition != null && condition.containsTable(tables);
+        boolean subContains = condition != null && condition.containsTable(tables);
+        return subContains || nextContainsTable(tables);
     }
 
     @Override


### PR DESCRIPTION
原有 OperatorSelectCondition#containsTable 会忽略后驱节点