### PR TITLE
QueryOrderBy 新增获取字段属性方法

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/QueryOrderBy.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/query/QueryOrderBy.java
@@ -71,7 +71,7 @@ public class QueryOrderBy implements CloneSupport<QueryOrderBy> {
     }
 
     public String getOrderType() {
-        return orderType;
+        return this.orderType;
     }
 
     public String toSql(List<QueryTable> queryTables, IDialect dialect) {


### PR DESCRIPTION
一些个性化功能需要获取 `QueryOrderBy` 中的 `queryColumn` 对象属性