### PR TITLE
feat(core): upgrade Jackson from 2.x to 3.0.4

### DIFF
--- a/mybatis-flex-core/pom.xml
+++ b/mybatis-flex-core/pom.xml
@@ -73,9 +73,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.0</version>
+            <version>3.0.4</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/handler/JacksonTypeHandler.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/handler/JacksonTypeHandler.java
@@ -15,12 +15,11 @@
  */
 package com.mybatisflex.core.handler;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mybatisflex.core.exception.FlexExceptions;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.json.JsonMapper;
 
-import java.io.IOException;
 import java.util.Collection;
 
 /**
@@ -28,7 +27,7 @@ import java.util.Collection;
  */
 public class JacksonTypeHandler extends BaseJsonTypeHandler<Object> {
 
-    private static ObjectMapper objectMapper;
+    private static JsonMapper objectMapper;
     private final Class<?> propertyType;
     private Class<?> genericType;
     private JavaType javaType;
@@ -50,7 +49,7 @@ public class JacksonTypeHandler extends BaseJsonTypeHandler<Object> {
             } else {
                 return getObjectMapper().readValue(json, propertyType);
             }
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw FlexExceptions.wrap(e, "Can not parseJson by JacksonTypeHandler: " + json);
         }
     }
@@ -59,27 +58,27 @@ public class JacksonTypeHandler extends BaseJsonTypeHandler<Object> {
     protected String toJson(Object object) {
         try {
             return getObjectMapper().writeValueAsString(object);
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             throw FlexExceptions.wrap(e, "Can not convert object to Json by JacksonTypeHandler: " + object);
         }
     }
 
-
+    @SuppressWarnings("unchecked")
     public JavaType getJavaType() {
-        if (javaType == null){
+        if (javaType == null) {
             javaType = getObjectMapper().getTypeFactory().constructCollectionType((Class<? extends Collection>) propertyType, genericType);
         }
         return javaType;
     }
 
-    public static ObjectMapper getObjectMapper() {
+    public static JsonMapper getObjectMapper() {
         if (null == objectMapper) {
-            objectMapper = new ObjectMapper();
+            objectMapper = JsonMapper.builder().build();
         }
         return objectMapper;
     }
 
-    public static void setObjectMapper(ObjectMapper objectMapper) {
+    public static void setObjectMapper(JsonMapper objectMapper) {
         JacksonTypeHandler.objectMapper = objectMapper;
     }
 

--- a/mybatis-flex-test/mybatis-flex-native-test/pom.xml
+++ b/mybatis-flex-test/mybatis-flex-native-test/pom.xml
@@ -75,9 +75,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.0</version>
+            <version>3.0.4</version>
         </dependency>
 
         <dependency>

--- a/mybatis-flex-test/mybatis-flex-native-test/src/test/java/com/mybatisflex/test/RelationsTest.java
+++ b/mybatis-flex-test/mybatis-flex-native-test/src/test/java/com/mybatisflex/test/RelationsTest.java
@@ -15,7 +15,7 @@
  */
 package com.mybatisflex.test;
 
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.json.JsonMapper;
 import com.mybatisflex.core.MybatisFlexBootstrap;
 import com.mybatisflex.core.audit.AuditManager;
 import com.mybatisflex.core.audit.ConsoleMessageCollector;


### PR DESCRIPTION
## Summary
- Upgrade Jackson dependency from `com.fasterxml.jackson.core:jackson-databind:2.15.0` to `tools.jackson.core:jackson-databind:3.0.4`
- Rewrite `JacksonTypeHandler` to use Jackson 3.x API: `JsonMapper` replaces `ObjectMapper`, `JacksonException` replaces `IOException`/`JsonProcessingException`
- Update package imports from `com.fasterxml.jackson` to `tools.jackson` in core module and native-test module

## Test plan
- [ ] Verify `JacksonTypeHandler` JSON serialization/deserialization works correctly
- [ ] Run `RelationsTest` to ensure Jackson integration in tests is functional
- [ ] Confirm no other modules are broken by the upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)