### PR TITLE
feat(core): 新增 TableInfoFactory.evict/LambdaUtil.clear 缓存清理 API

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexCaches.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexCaches.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2022-2025, Mybatis-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.mybatisflex.core;
+
+import com.mybatisflex.core.table.TableInfoFactory;
+import com.mybatisflex.core.util.LambdaUtil;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * mybatis-flex 内部缓存的统一操作入口（Facade）。
+ *
+ * <p>flex 在运行期维护了两组解析缓存：
+ * <ul>
+ *     <li>{@link TableInfoFactory} —— 实体类 / 表名 / Mapper 与 {@link com.mybatisflex.core.table.TableInfo} 的映射；</li>
+ *     <li>{@link LambdaUtil} —— Lambda getter 的字段名 / 归属类 / QueryColumn 解析结果。</li>
+ * </ul>
+ *
+ * <p>正常运行时缓存应保持稳定，不应清理。以下场景例外：
+ * <ul>
+ *     <li>开发期与 JRebel / Spring Boot DevTools 等热加载工具配合，实体类被重新加载后，
+ *         需要强制 flex 用最新的 Class 重新解析；</li>
+ *     <li>单元测试之间希望隔离，避免上一个用例遗留的 TableInfo 影响下一个用例。</li>
+ * </ul>
+ *
+ * <p>本类只处理 flex 自身的缓存，<b>不会</b>触碰 MyBatis {@code Configuration} 内的 MappedStatement，
+ * 也不会重建业务侧的 Spring bean。完整的热加载还需要业务侧在合适时机自行重建这些资源。
+ *
+ * @author mybatis-flex
+ * @since 1.11.9
+ */
+public class FlexCaches {
+
+    private FlexCaches() {
+    }
+
+    /**
+     * 清除指定实体类在 flex 内部的所有缓存：
+     * 委托给 {@link TableInfoFactory#evict(Class)} 与 {@link LambdaUtil#clear()}。
+     *
+     * <p>注意：{@link LambdaUtil} 的键是 Lambda 合成类（例如 {@code Foo$$Lambda$123}），
+     * 与实体类不是一一对应，因此这里采用"整表清空"策略而非按实体粒度清理。
+     * 这是刻意的取舍 —— 精细化清理需要遍历每个 QueryColumn 反查其归属实体，得不偿失。
+     *
+     * @param entityClass 实体类，允许为 {@code null}（此时只清 Lambda 缓存）
+     * @return 一份简短的清理报告，形如 {@code "TableInfo=3, Lambda=17"}
+     */
+    public static String evictEntity(@Nullable Class<?> entityClass) {
+        int tableInfoRemoved = TableInfoFactory.evict(entityClass);
+        int lambdaRemoved = LambdaUtil.clear();
+        return "TableInfo=" + tableInfoRemoved + ", Lambda=" + lambdaRemoved;
+    }
+
+    /**
+     * 清空 flex 内部的全部缓存：
+     * 委托给 {@link TableInfoFactory#clear()} 与 {@link LambdaUtil#clear()}。
+     *
+     * @return 一份简短的清理报告，形如 {@code "TableInfo=8, Lambda=17"}
+     */
+    public static String clearAll() {
+        int tableInfoRemoved = TableInfoFactory.clear();
+        int lambdaRemoved = LambdaUtil.clear();
+        return "TableInfo=" + tableInfoRemoved + ", Lambda=" + lambdaRemoved;
+    }
+
+}

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfoFactory.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/table/TableInfoFactory.java
@@ -76,6 +76,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -639,6 +640,72 @@ public class TableInfoFactory {
             }
         }
         return false;
+    }
+
+
+    /**
+     * 清除指定实体类的缓存，包括 {@link #entityTableMap}、{@link #tableInfoMap}
+     * 以及 {@link #mapperTableInfoMap} 中所有指向该实体 {@link TableInfo} 的条目。
+     *
+     * <p>典型用途是开发期与热加载工具（例如 JRebel、Spring Boot DevTools）配合，
+     * 当实体类被重新加载（增/删字段、修改注解）后，先调用本方法清理旧的 TableInfo，
+     * 下一次 {@link #ofEntityClass(Class)} 就会用最新的 Class 重新解析。
+     *
+     * <p>注意：本方法只处理 flex 内部的三个缓存，并不会重建
+     * MyBatis {@code Configuration} 中已注册的 MappedStatement，
+     * 也不会影响已经生成的 QueryColumn 常量（如通过 annotation processor 生成的 XxxTableDef）。
+     * 完整的热加载还需要业务侧配合销毁并重建 SqlSessionFactory / Spring bean。
+     *
+     * @param entityClass 实体类，允许为 {@code null}（此时直接返回 0）
+     * @return 实际被清除的缓存条目数（0 表示原本就没有缓存）
+     * @since 1.11.9
+     */
+    public static int evict(@Nullable Class<?> entityClass) {
+        if (entityClass == null) {
+            return 0;
+        }
+        int removed = 0;
+        TableInfo tableInfo = entityTableMap.remove(entityClass);
+        if (tableInfo != null) {
+            removed++;
+            // tableInfoMap 中可能有其它 VO/Entity 指向同一个 TableInfo，仅在引用一致时移除
+            String tableKey = tableInfo.getTableNameWithSchema();
+            if (tableKey != null && tableInfoMap.get(tableKey) == tableInfo) {
+                tableInfoMap.remove(tableKey);
+                removed++;
+            }
+            // mapperTableInfoMap 中所有指向该 TableInfo 的 mapper 条目一并移除
+            Iterator<Map.Entry<Class<?>, TableInfo>> it = mapperTableInfoMap.entrySet().iterator();
+            while (it.hasNext()) {
+                if (it.next().getValue() == tableInfo) {
+                    it.remove();
+                    removed++;
+                }
+            }
+        }
+        return removed;
+    }
+
+
+    /**
+     * 清空 {@link TableInfoFactory} 的全部缓存：
+     * {@link #entityTableMap}、{@link #mapperTableInfoMap}、{@link #tableInfoMap}。
+     *
+     * <p>调用后所有实体的 {@link TableInfo} 都会在下一次访问时按当前 Class 重新构建。
+     * 仅用于开发期热加载 / 单元测试隔离等场景，生产环境无需调用。
+     *
+     * <p>{@link #initializedPackageNames} 不会被清空 —— 之前已经扫过的 mapper 包，
+     * 无需再次触发 {@link #init(String)} 扫描。
+     *
+     * @return 清空前三张缓存中的条目总数
+     * @since 1.11.9
+     */
+    public static int clear() {
+        int total = entityTableMap.size() + mapperTableInfoMap.size() + tableInfoMap.size();
+        entityTableMap.clear();
+        mapperTableInfoMap.clear();
+        tableInfoMap.clear();
+        return total;
     }
 
 }

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/LambdaUtil.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/util/LambdaUtil.java
@@ -115,6 +115,27 @@ public class LambdaUtil {
     }
 
 
+    /**
+     * 清空 {@link LambdaUtil} 内部的三张 Lambda 解析缓存：
+     * {@code fieldNameMap}、{@code implClassMap}、{@code queryColumnMap}。
+     *
+     * <p>典型场景：开发期热加载后，旧的 Lambda 合成类可能已随 ClassLoader 一同废弃，
+     * 或实体类字段发生了变更，需要让下一次 {@code getFieldName} / {@code getQueryColumn}
+     * 按最新的 Class 重新解析。生产环境无需调用。
+     *
+     * <p>通常与 {@link TableInfoFactory#clear()} 配合使用，
+     * 以保证 TableInfo 与 Lambda 缓存同时失效。
+     *
+     * @return 清空前三张缓存中的条目总数
+     * @since 1.11.9
+     */
+    public static int clear() {
+        int total = fieldNameMap.size() + implClassMap.size() + queryColumnMap.size();
+        fieldNameMap.clear();
+        implClassMap.clear();
+        queryColumnMap.clear();
+        return total;
+    }
 
 
 }

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/core/FlexCachesTest.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/core/FlexCachesTest.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2022-2025, Mybatis-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.mybatisflex.core;
+
+import com.mybatisflex.core.table.TableInfo;
+import com.mybatisflex.core.table.TableInfoFactory;
+import com.mybatisflex.coretest.Account;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * 覆盖 {@link FlexCaches} 门面。
+ */
+public class FlexCachesTest {
+
+    /**
+     * 前后各清一次缓存，避免与其他测试（例如 {@code LambdaUtilTest.testIssue516} 的绝对 size 断言）互相污染。
+     */
+    @Before
+    public void resetBefore() {
+        FlexCaches.clearAll();
+    }
+
+    @After
+    public void resetAfter() {
+        FlexCaches.clearAll();
+    }
+
+    @Test
+    public void evictEntityReportsCounts() {
+        TableInfoFactory.ofEntityClass(Account.class);
+        String report = FlexCaches.evictEntity(Account.class);
+        Assert.assertNotNull(report);
+        Assert.assertTrue("report 应包含 TableInfo 段", report.contains("TableInfo="));
+        Assert.assertTrue("report 应包含 Lambda 段", report.contains("Lambda="));
+    }
+
+    @Test
+    public void clearAllEmptiesEverything() {
+        TableInfo ti = TableInfoFactory.ofEntityClass(Account.class);
+        Assert.assertNotNull(ti);
+
+        String report = FlexCaches.clearAll();
+        Assert.assertNotNull(report);
+
+        // 紧接一次 clear，两个计数应为 0
+        Assert.assertEquals("TableInfo=0, Lambda=0", FlexCaches.clearAll());
+    }
+
+    @Test
+    public void evictEntityAcceptsNull() {
+        // 仅 Lambda 会被清（可能为 0），不应抛异常
+        String report = FlexCaches.evictEntity(null);
+        Assert.assertTrue(report.startsWith("TableInfo=0"));
+    }
+
+}

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/core/table/TableInfoFactoryEvictTest.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/core/table/TableInfoFactoryEvictTest.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2022-2025, Mybatis-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.mybatisflex.core.table;
+
+import com.mybatisflex.coretest.Account;
+import com.mybatisflex.coretest.Article;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * 覆盖 {@link TableInfoFactory#evict(Class)} 与 {@link TableInfoFactory#clear()}。
+ */
+public class TableInfoFactoryEvictTest {
+
+    /**
+     * 前后各清一次，避免与其他测试互相污染。
+     */
+    @Before
+    public void resetBefore() {
+        TableInfoFactory.clear();
+    }
+
+    @After
+    public void resetAfter() {
+        TableInfoFactory.clear();
+    }
+
+    @Test
+    public void evictNullReturnsZero() {
+        Assert.assertEquals(0, TableInfoFactory.evict(null));
+    }
+
+    @Test
+    public void evictRemovesEntityAndReturnsFreshInstanceOnNextFetch() {
+        // 先触发缓存
+        TableInfo before = TableInfoFactory.ofEntityClass(Account.class);
+        Assert.assertNotNull(before);
+
+        // 清除
+        int removed = TableInfoFactory.evict(Account.class);
+        Assert.assertTrue("应至少清掉 entityTableMap 中的一条", removed >= 1);
+
+        // 第二次 evict 应返回 0（幂等）
+        Assert.assertEquals(0, TableInfoFactory.evict(Account.class));
+
+        // 再取一次，flex 会重新构建 —— 应当是新的 TableInfo 实例
+        TableInfo after = TableInfoFactory.ofEntityClass(Account.class);
+        Assert.assertNotNull(after);
+        Assert.assertNotSame("evict 后应重新构建 TableInfo", before, after);
+    }
+
+    @Test
+    public void clearEmptiesAllCaches() {
+        // 预热两张表
+        TableInfoFactory.ofEntityClass(Account.class);
+        TableInfoFactory.ofEntityClass(Article.class);
+
+        int removed = TableInfoFactory.clear();
+        Assert.assertTrue("clear() 应清掉至少两条 entityTableMap 记录", removed >= 2);
+
+        // clear() 后紧接着再调用一次，返回 0
+        Assert.assertEquals(0, TableInfoFactory.clear());
+
+        // 后续依旧能取到 TableInfo
+        Assert.assertNotNull(TableInfoFactory.ofEntityClass(Account.class));
+    }
+
+}

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/core/util/LambdaUtilClearTest.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/core/util/LambdaUtilClearTest.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2022-2025, Mybatis-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.mybatisflex.core.util;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * 覆盖 {@link LambdaUtil#clear()}。
+ */
+public class LambdaUtilClearTest {
+
+    /**
+     * 每个用例前后都清空缓存，避免与 flex 其它 Lambda 相关测试（例如 {@code LambdaUtilTest.testIssue516}
+     * 的绝对 size 断言）互相污染 —— 每一处 {@code TestAccount::getName} call-site
+     * 都会生成一份独立的 synthetic Lambda 类，作为独立 key 进入 {@code fieldNameMap}。
+     */
+    @Before
+    public void resetBefore() {
+        LambdaUtil.clear();
+    }
+
+    @After
+    public void resetAfter() {
+        LambdaUtil.clear();
+    }
+
+    @Test
+    public void clearEmptiesFieldNameCache() {
+        // 触发缓存：同一 call-site 多次调用只占一格
+        for (int i = 0; i < 10; i++) {
+            LambdaUtil.getFieldName(TestAccount::getName);
+            LambdaUtil.getFieldName(TestAccount::getAge);
+        }
+        Assert.assertTrue("清理前应至少有 1 条 fieldNameMap 记录",
+            LambdaUtil.getFieldNameMap().size() >= 1);
+
+        int removed = LambdaUtil.clear();
+        Assert.assertTrue("clear() 至少应清掉刚才缓存的 fieldNameMap 条目", removed >= 1);
+        Assert.assertEquals(0, LambdaUtil.getFieldNameMap().size());
+
+        // clear() 幂等：紧接再调，返回 0
+        Assert.assertEquals(0, LambdaUtil.clear());
+
+        // 清理后 getFieldName 仍能正常工作（会重新解析并入缓存）
+        Assert.assertEquals("name", LambdaUtil.getFieldName(TestAccount::getName));
+        Assert.assertEquals(1, LambdaUtil.getFieldNameMap().size());
+    }
+
+}


### PR DESCRIPTION
开发期使用 JRebel / Spring Boot DevTools 热加载时，实体类被重新加载后 flex 仍持有旧的 TableInfo 与 Lambda 解析缓存，导致热加载失效、只能重启 JVM。本提交为此类场景提供主动清理 flex 内部缓存的官方入口。

新增 API：
- TableInfoFactory.evict(Class)：按实体类精确清理 entityTableMap / tableInfoMap / mapperTableInfoMap。后两张表按引用相等（==）判断是否移除，避免误删 VO 与 Entity 共享的 TableInfo（ofEntityClass 使用 putIfAbsent，先入者为主）。
- TableInfoFactory.clear()：清空全部 TableInfo 缓存，但保留 initializedPackageNames，避免重复扫描 Mapper 包。
- LambdaUtil.clear()：清空 fieldNameMap / implClassMap / queryColumnMap 三张 Lambda 解析缓存。
- FlexCaches（新增统一门面类）：提供 evictEntity(Class) 与 clearAll()，返回形如 `TableInfo=3, Lambda=17` 的清理报告。

LambdaUtil 不单独提供 evict(Class)：其缓存 key 是 Lambda 合成类（例如 Foo$$Lambda$14），与实体类并非一一对应，无法按实体粒度精确清理，因此仅提供整体 clear() 方法。

新增 7 个单元测试，测试全部通过。