### PR TITLE
fix(core): 修复 UpdateChain.remove() 未生成 WITH 子句的问题

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/CommonsDialectImpl.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/dialect/impl/CommonsDialectImpl.java
@@ -396,6 +396,13 @@ public class CommonsDialectImpl implements IDialect {
 
 
     ////////////build query sql///////
+    protected void buildWithSql(StringBuilder sqlBuilder, QueryWrapper queryWrapper) {
+        With with = CPI.getWith(queryWrapper);
+        if (with != null) {
+            sqlBuilder.append(with.toSql(this));
+        }
+    }
+
     @Override
     public String buildSelectSql(QueryWrapper queryWrapper) {
         return buildSelectSql(queryWrapper, Collections.emptyList());
@@ -441,10 +448,7 @@ public class CommonsDialectImpl implements IDialect {
         }
 
         StringBuilder sqlBuilder = new StringBuilder();
-        With with = CPI.getWith(queryWrapper);
-        if (with != null) {
-            sqlBuilder.append(with.toSql(this));
-        }
+        buildWithSql(sqlBuilder, queryWrapper);
 
         buildSelectColumnSql(sqlBuilder, allTables, selectColumns, CPI.getHint(queryWrapper));
 
@@ -545,7 +549,9 @@ public class CommonsDialectImpl implements IDialect {
         List<QueryTable> allTables = CollectionUtil.merge(queryTables, joinTables);
 
         // ignore selectColumns
-        StringBuilder sqlBuilder = new StringBuilder(DELETE);
+        StringBuilder sqlBuilder = new StringBuilder();
+        buildWithSql(sqlBuilder, queryWrapper);
+        sqlBuilder.append(DELETE);
         String hint = CPI.getHint(queryWrapper);
         if (StringUtil.hasText(hint)) {
             sqlBuilder.append(BLANK).append(hint).deleteCharAt(sqlBuilder.length() - 1);
@@ -814,7 +820,9 @@ public class CommonsDialectImpl implements IDialect {
         List<QueryTable> allTables = CollectionUtil.merge(queryTables, joinTables);
 
         // ignore selectColumns
-        StringBuilder sqlBuilder = new StringBuilder(UPDATE).append(forHint(CPI.getHint(queryWrapper)));
+        StringBuilder sqlBuilder = new StringBuilder();
+        buildWithSql(sqlBuilder, queryWrapper);
+        sqlBuilder.append(UPDATE).append(forHint(CPI.getHint(queryWrapper)));
         sqlBuilder.append(tableInfo.getWrapSchemaAndTableName(this, OperateType.DELETE));
         sqlBuilder.append(SET).append(buildLogicDeletedSet(logicDeleteColumn, tableInfo));
 

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/AccountSqlTester.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/coretest/AccountSqlTester.java
@@ -25,6 +25,8 @@ import com.mybatisflex.core.dialect.impl.CommonsDialectImpl;
 import com.mybatisflex.core.dialect.impl.OracleDialect;
 import com.mybatisflex.core.query.CPI;
 import com.mybatisflex.core.query.DistinctQueryColumn;
+import com.mybatisflex.core.query.QueryColumn;
+import com.mybatisflex.core.query.QueryTable;
 import com.mybatisflex.core.query.QueryWrapper;
 import com.mybatisflex.core.query.RawQueryColumn;
 import com.mybatisflex.core.query.SqlOperators;
@@ -664,6 +666,53 @@ public class AccountSqlTester {
                 "LEFT JOIN `tb_article` ON `tb_account`.`id` = `tb_article`.`account_id` " +
                 "WHERE `tb_account`.`user_name` = ?"
             , sql);
+        System.out.println(sql);
+    }
+
+    @Test
+    public void testDeleteWithRecursive() {
+        QueryTable cte = new QueryTable("CTE");
+        QueryWrapper queryWrapper = QueryWrapper.create()
+            .withRecursive("CTE").asSelect(
+                select().from(ACCOUNT).where(ACCOUNT.ID.eq(10))
+            )
+            .from(ACCOUNT)
+            .where(ACCOUNT.ID.in(select(new QueryColumn(cte, "id")).from(cte)))
+            .and(ACCOUNT.AGE.eq(20));
+
+        IDialect dialect = new CommonsDialectImpl();
+        String sql = dialect.forDeleteByQuery(queryWrapper);
+
+        Assert.assertEquals("WITH RECURSIVE CTE AS (" +
+                "SELECT * FROM `tb_account` WHERE `id` = ?" +
+                ") DELETE FROM `tb_account` WHERE `id` IN (SELECT `id` FROM `CTE`) AND `age` = ?"
+            , sql);
+        Assert.assertArrayEquals(new Object[]{10, 20}, CPI.getValueArray(queryWrapper));
+        System.out.println(sql);
+    }
+
+    @Test
+    public void testLogicDeleteWithRecursive() {
+        QueryTable cte = new QueryTable("CTE");
+        QueryWrapper queryWrapper = QueryWrapper.create()
+            .withRecursive("CTE").asSelect(
+                select().from(ACCOUNT).where(ACCOUNT.ID.eq(10))
+            )
+            .from(ACCOUNT)
+            .where(ACCOUNT.ID.in(select(new QueryColumn(cte, "id")).from(cte)))
+            .and(ACCOUNT.AGE.eq(20));
+
+        IDialect dialect = new CommonsDialectImpl();
+        TableInfo tableInfo = TableInfoFactory.ofEntityClass(Account.class);
+        tableInfo.appendConditions(null, queryWrapper);
+        String sql = dialect.forDeleteEntityBatchByQuery(tableInfo, queryWrapper);
+
+        Assert.assertEquals("WITH RECURSIVE CTE AS (" +
+                "SELECT * FROM `tb_account` WHERE `id` = ?" +
+                ") UPDATE `tb_account` SET `is_delete` = 1 " +
+                "WHERE (`id` IN (SELECT `id` FROM `CTE`) AND `age` = ?) AND `is_delete` = ?"
+            , sql);
+        Assert.assertArrayEquals(new Object[]{10, 20, 0}, CPI.getValueArray(queryWrapper));
         System.out.println(sql);
     }
 


### PR DESCRIPTION
## 问题描述

使用 `UpdateChain.withRecursive(...).remove()` 删除数据时，最终生成的删除语句中没有包含 `WITH RECURSIVE` 子句，导致递归 CTE 删除条件无法生效。

Fixes #676

## 问题原因

`CommonsDialectImpl` 在构建 SELECT SQL 时会处理 `QueryWrapper` 中的 `With`，但以下删除路径没有输出该部分：

- `buildDeleteSql()` 构建的物理删除 SQL
- `forDeleteEntityBatchByQuery()` 构建的逻辑删除 UPDATE SQL

## 修改内容

- 抽取 `buildWithSql(...)`，复用原有 CTE 构建逻辑。
- 在物理删除的 `DELETE` 关键字前输出 `WITH / WITH RECURSIVE`。
- 在逻辑删除的 `UPDATE` 关键字前输出 `WITH / WITH RECURSIVE`。
- 保持原有 SELECT 和不带 WITH 的删除 SQL 行为不变。
- 保持 CTE 参数、外层查询参数以及逻辑删除参数的原有顺序。

## 测试

新增回归测试，覆盖：

- 带递归 CTE 的物理删除 SQL
- 带递归 CTE 的逻辑删除 UPDATE SQL
- CTE 参数、外层查询参数和逻辑删除参数的顺序

已执行：

```shell
mvn -pl mybatis-flex-core "-Dtest=WithSQLTester,AccountSqlTester" test
mvn -pl mybatis-flex-core "-Dtest=AuthTest" test
mvn -pl mybatis-flex-core test