### PR TITLE
feat(core): FlexCaches 新增 SqlSessionFactory 重载，支持清理MyBatis层缓存

### DIFF
--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexCaches.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/FlexCaches.java
@@ -15,8 +15,10 @@
  */
 package com.mybatisflex.core;
 
+import com.mybatisflex.core.mybatis.FlexConfiguration;
 import com.mybatisflex.core.table.TableInfoFactory;
 import com.mybatisflex.core.util.LambdaUtil;
+import org.apache.ibatis.session.SqlSessionFactory;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -54,6 +56,11 @@ public class FlexCaches {
      * 与实体类不是一一对应，因此这里采用"整表清空"策略而非按实体粒度清理。
      * 这是刻意的取舍 —— 精细化清理需要遍历每个 QueryColumn 反查其归属实体，得不偿失。
      *
+     * <p><b>不清理 MyBatis 层缓存</b>。若在热加载场景下改了实体字段类型，老的
+     * {@code Configuration.resultMaps} 和 {@code FlexConfiguration.dynamicMappedStatementCache}
+     * 会导致查询仍复用旧的 ResultMap（旧 javaType），此时应使用
+     * {@link #evictEntity(SqlSessionFactory, Class)} 重载一并清理。
+     *
      * @param entityClass 实体类，允许为 {@code null}（此时只清 Lambda 缓存）
      * @return 一份简短的清理报告，形如 {@code "TableInfo=3, Lambda=17"}
      */
@@ -64,8 +71,65 @@ public class FlexCaches {
     }
 
     /**
+     * 清除指定实体类的缓存，<b>同时清理 MyBatis 层的 ResultMap / 动态 MappedStatement 缓存</b>。
+     *
+     * <p>相比 {@link #evictEntity(Class)}，本重载额外清理：
+     * <ul>
+     *     <li>{@link FlexConfiguration#dynamicMappedStatementCache} 中 key 以
+     *         {@code ":<entityFQN>"} 结尾的条目（泛型/共享 mapper 场景）；</li>
+     *     <li>{@code Configuration.resultMaps} 中 key 等于实体全限定名、或
+     *         以 {@code "<entityFQN>-"} 开头的条目（具体 mapper 场景）。</li>
+     * </ul>
+     *
+     * <p>适用于 JRebel / DevTools 等热加载场景：改 {@code @Table} 实体字段类型后，
+     * 若只清 flex 自身缓存，{@link FlexConfiguration#replaceResultMap} 会复用老的
+     * ResultMap（老 javaType），导致类型转换异常（如 Oracle 17059）。
+     *
+     * <p>若传入的 {@code sqlSessionFactory} 为 {@code null}，或其 Configuration
+     * 不是 {@link FlexConfiguration}，则退化为只清 flex 自身缓存，与
+     * {@link #evictEntity(Class)} 行为一致。
+     *
+     * @param sqlSessionFactory 当前应用的 SqlSessionFactory，可为 {@code null}
+     * @param entityClass       实体类，允许为 {@code null}（此时只清 Lambda 缓存）
+     * @return 一份简短的清理报告，形如
+     *         {@code "TableInfo=3, Lambda=17, MappedStatement=2, ResultMap=1"}；
+     *         当未提供可用的 FlexConfiguration 时，后两项不出现
+     * @since 1.11.9
+     */
+    public static String evictEntity(@Nullable SqlSessionFactory sqlSessionFactory,
+                                     @Nullable Class<?> entityClass) {
+        String flexReport = evictEntity(entityClass);
+        if (sqlSessionFactory == null) {
+            return flexReport;
+        }
+        org.apache.ibatis.session.Configuration configuration = sqlSessionFactory.getConfiguration();
+        if (!(configuration instanceof FlexConfiguration)) {
+            return flexReport;
+        }
+        int msBefore = 0;
+        int rmBefore = 0;
+        // 仅在 entityClass 非空时统计 MyBatis 层清理数（与 FlexConfiguration.evictEntity 行为一致）
+        if (entityClass != null) {
+            String fqn = entityClass.getName();
+            String suffix = ":" + fqn;
+            // dynamicMappedStatementCache 是 static 字段，直接通过类访问
+            // 这里通过 FlexConfiguration 实例方法统一清理，并由该方法维护计数语义
+            msBefore = countMatchingMsCache(fqn);
+            rmBefore = countMatchingResultMaps(configuration, fqn);
+            ((FlexConfiguration) configuration).evictEntity(entityClass);
+            int msRemoved = msBefore - countMatchingMsCache(fqn);
+            int rmRemoved = rmBefore - countMatchingResultMaps(configuration, fqn);
+            return flexReport + ", MappedStatement=" + msRemoved + ", ResultMap=" + rmRemoved;
+        }
+        return flexReport;
+    }
+
+    /**
      * 清空 flex 内部的全部缓存：
      * 委托给 {@link TableInfoFactory#clear()} 与 {@link LambdaUtil#clear()}。
+     *
+     * <p><b>不清理 MyBatis 层缓存</b>。若在热加载场景下需要一并清理 ResultMap /
+     * 动态 MappedStatement 缓存，使用 {@link #clearAll(SqlSessionFactory)} 重载。
      *
      * @return 一份简短的清理报告，形如 {@code "TableInfo=8, Lambda=17"}
      */
@@ -73,6 +137,66 @@ public class FlexCaches {
         int tableInfoRemoved = TableInfoFactory.clear();
         int lambdaRemoved = LambdaUtil.clear();
         return "TableInfo=" + tableInfoRemoved + ", Lambda=" + lambdaRemoved;
+    }
+
+    /**
+     * 清空 flex 内部的全部缓存，<b>同时清空 MyBatis 层的动态 MappedStatement 缓存</b>。
+     *
+     * <p>相比 {@link #clearAll()}，本重载额外清理：
+     * <ul>
+     *     <li>{@link FlexConfiguration#dynamicMappedStatementCache}（全部清空）；</li>
+     * </ul>
+     *
+     * <p>注意：{@code Configuration.resultMaps} 不在此方法中全部清空——它同时承载
+     * 业务侧 XML/注解声明的 ResultMap，误删会影响正常查询。如需按实体粒度清理，
+     * 请使用 {@link #evictEntity(SqlSessionFactory, Class)}。
+     *
+     * @param sqlSessionFactory 当前应用的 SqlSessionFactory，可为 {@code null}
+     * @return 一份简短的清理报告，形如
+     *         {@code "TableInfo=8, Lambda=17, MappedStatement=42"}；
+     *         当未提供可用的 FlexConfiguration 时，最后一项不出现
+     * @since 1.11.9
+     */
+    public static String clearAll(@Nullable SqlSessionFactory sqlSessionFactory) {
+        String flexReport = clearAll();
+        if (sqlSessionFactory == null) {
+            return flexReport;
+        }
+        org.apache.ibatis.session.Configuration configuration = sqlSessionFactory.getConfiguration();
+        if (!(configuration instanceof FlexConfiguration)) {
+            return flexReport;
+        }
+        // 清 dynamicMappedStatementCache（static 字段，全清）
+        int msBefore = FlexConfiguration.getDynamicMappedStatementCacheSize();
+        ((FlexConfiguration) configuration).clearDynamicMappedStatementCache();
+        int msRemoved = msBefore - FlexConfiguration.getDynamicMappedStatementCacheSize();
+        return flexReport + ", MappedStatement=" + msRemoved;
+    }
+
+    // ---- 内部辅助：统计 dynamicMappedStatementCache 中匹配指定 FQN 的条目数 ----
+
+    private static int countMatchingMsCache(String entityFqn) {
+        String suffix = ":" + entityFqn;
+        int count = 0;
+        for (String key : FlexConfiguration.getDynamicMappedStatementCacheKeys()) {
+            if (key.endsWith(suffix)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    // ---- 内部辅助：统计 Configuration.resultMaps 中匹配指定 FQN 的条目数 ----
+
+    private static int countMatchingResultMaps(org.apache.ibatis.session.Configuration configuration,
+                                               String entityFqn) {
+        int count = 0;
+        for (String key : configuration.getResultMapNames()) {
+            if (key.equals(entityFqn) || key.startsWith(entityFqn + "-")) {
+                count++;
+            }
+        }
+        return count;
     }
 
 }

--- a/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/FlexConfiguration.java
+++ b/mybatis-flex-core/src/main/java/com/mybatisflex/core/mybatis/FlexConfiguration.java
@@ -51,6 +51,7 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -233,6 +234,74 @@ public class FlexConfiguration extends Configuration {
             .useCache(ms.isUseCache())
             .cache(ms.getCache())
             .build();
+    }
+
+    /**
+     * 清理指定实体在 MyBatis 层的两处 ResultMap 缓存,用于热加载场景。
+     *
+     * <p>改 {@code @Table} 实体字段类型后,仅清 {@link TableInfoFactory} 的 TableInfo 缓存不够:
+     * {@link #replaceResultMap} 在 {@code hasResultMap(entityFQN)} 为 true 时会复用老的
+     * {@link ResultMap}(老的 javaType),导致类型转换异常(如 Oracle 17059)。本方法把两处
+     * 缓存一并清掉,下次查询用最新 TableInfo 重建 ResultMap。
+     *
+     * <p>清理范围:
+     * <ul>
+     *   <li>{@link #dynamicMappedStatementCache} -- 移除 key 后缀为 {@code ":<entityFQN>"} 的条目
+     *       (泛型/共享 mapper 场景写入);</li>
+     *   <li>{@link Configuration#resultMaps} -- 移除 key 等于 entityFQN 或以 {@code "<entityFQN>-"} 开头的条目
+     *       (具体 mapper 场景写入)。{@code resultMaps} 实际类型是 MyBatis 的 {@code StrictMap},
+     *       其 {@code removeIf} 继承自 {@code HashMap} 无 strict 检查,可安全移除。</li>
+     * </ul>
+     *
+     * <p><b>不自动生效</b>:本方法只是公开 API,flex 内部不订阅 reload 事件,需调用方在实体重加载
+     * 时机显式调用(JRebel listener / DevTools / 手动)。
+     *
+     * @param entityClass 实体类;{@code null} 时直接返回
+     * @since 1.11.9
+     */
+    public void evictEntity(Class<?> entityClass) {
+        if (entityClass == null) {
+            return;
+        }
+        String fqn = entityClass.getName();
+        dynamicMappedStatementCache.entrySet().removeIf(e -> e.getKey().endsWith(":" + fqn));
+        resultMaps.entrySet().removeIf(
+            e -> e.getKey().equals(fqn) || e.getKey().startsWith(fqn + "-"));
+    }
+
+    /**
+     * 返回 {@link #dynamicMappedStatementCache} 中所有 key 的快照（副本）。
+     *
+     * <p>用于排查/统计，非高频路径使用。返回的是调用时的快照，后续缓存变更不影响返回值。
+     *
+     * @return key 集合的快照
+     * @since 1.11.9
+     */
+    public static Set<String> getDynamicMappedStatementCacheKeys() {
+        return new java.util.HashSet<>(dynamicMappedStatementCache.keySet());
+    }
+
+    /**
+     * 返回 {@link #dynamicMappedStatementCache} 当前条目数。
+     *
+     * @return 动态 MappedStatement 缓存条目数
+     * @since 1.11.9
+     */
+    public static int getDynamicMappedStatementCacheSize() {
+        return dynamicMappedStatementCache.size();
+    }
+
+    /**
+     * 清空 {@link #dynamicMappedStatementCache}（static 全局缓存）。
+     *
+     * <p>注意：这是全局操作，会影响所有使用同一 ClassLoader 的 SqlSessionFactory。
+     * 一般仅用于"全量热加载/测试隔离"场景；按实体粒度清理请用
+     * {@link #evictEntity(Class)}。
+     *
+     * @since 1.11.9
+     */
+    public static void clearDynamicMappedStatementCache() {
+        dynamicMappedStatementCache.clear();
     }
 
     /**

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/core/FlexCachesTest.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/core/FlexCachesTest.java
@@ -15,13 +15,24 @@
  */
 package com.mybatisflex.core;
 
+import com.mybatisflex.core.mybatis.FlexConfiguration;
 import com.mybatisflex.core.table.TableInfo;
 import com.mybatisflex.core.table.TableInfoFactory;
 import com.mybatisflex.coretest.Account;
+import com.mybatisflex.coretest.Article;
+import org.apache.ibatis.mapping.ResultMap;
+import org.apache.ibatis.mapping.ResultMapping;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.type.JdbcType;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
 
 /**
  * 覆盖 {@link FlexCaches} 门面。
@@ -67,6 +78,139 @@ public class FlexCachesTest {
         // 仅 Lambda 会被清（可能为 0），不应抛异常
         String report = FlexCaches.evictEntity(null);
         Assert.assertTrue(report.startsWith("TableInfo=0"));
+    }
+
+    // ==================== SqlSessionFactory 重载（MyBatis 层清理）====================
+
+    @Test
+    public void evictEntityWithNullSessionFactoryDegrades() {
+        // SqlSessionFactory 为 null 时，行为等同于无 SqlSessionFactory 的重载
+        TableInfoFactory.ofEntityClass(Account.class);
+        String report = FlexCaches.evictEntity((SqlSessionFactory) null, Account.class);
+        Assert.assertTrue(report.contains("TableInfo="));
+        Assert.assertTrue(report.contains("Lambda="));
+        Assert.assertFalse("不应包含 MappedStatement 段", report.contains("MappedStatement="));
+        Assert.assertFalse("不应包含 ResultMap 段", report.contains("ResultMap="));
+    }
+
+    @Test
+    public void evictEntityWithNonFlexConfigurationDegrades() {
+        // Configuration 不是 FlexConfiguration 时，降级到只清 flex 自身
+        SqlSessionFactory ssf = mockSqlSessionFactory(new Configuration());
+        TableInfoFactory.ofEntityClass(Account.class);
+        String report = FlexCaches.evictEntity(ssf, Account.class);
+        Assert.assertTrue(report.contains("TableInfo="));
+        Assert.assertFalse("非 FlexConfiguration 不应包含 MappedStatement 段", report.contains("MappedStatement="));
+    }
+
+    @Test
+    public void evictEntityWithFlexConfigurationClearsMyBatisCaches() {
+        FlexConfiguration flexCfg = new FlexConfiguration();
+        SqlSessionFactory ssf = mockSqlSessionFactory(flexCfg);
+
+        // 预热 TableInfo
+        TableInfoFactory.ofEntityClass(Account.class);
+
+        // 造 dynamicMappedStatementCache 条目
+        seedDynamicMsCache("mapper1.selectList:" + Account.class.getName());
+        seedDynamicMsCache("mapper2.selectOne:" + Account.class.getName());
+        seedDynamicMsCache("mapper3.selectList:" + Article.class.getName()); // 不匹配
+
+        // 造 resultMaps 条目
+        addFakeResultMap(flexCfg, Account.class.getName(), Account.class);
+        addFakeResultMap(flexCfg, Account.class.getName() + "-inline", Account.class);
+        addFakeResultMap(flexCfg, Article.class.getName(), Article.class);
+
+        String report = FlexCaches.evictEntity(ssf, Account.class);
+
+        Assert.assertTrue("报告应含 TableInfo 段", report.contains("TableInfo="));
+        Assert.assertTrue("报告应含 Lambda 段", report.contains("Lambda="));
+        Assert.assertTrue("报告应含 MappedStatement 段", report.contains("MappedStatement="));
+        Assert.assertTrue("报告应含 ResultMap 段", report.contains("ResultMap="));
+
+        // 验证 dynamicMappedStatementCache：Account 的两条被清，Article 的一条保留
+        Assert.assertEquals(1, FlexConfiguration.getDynamicMappedStatementCacheSize());
+
+        // 验证 resultMaps：Account 的两个被清，Article 的保留
+        Assert.assertFalse(flexCfg.hasResultMap(Account.class.getName()));
+        Assert.assertFalse(flexCfg.hasResultMap(Account.class.getName() + "-inline"));
+        Assert.assertTrue(flexCfg.hasResultMap(Article.class.getName()));
+    }
+
+    @Test
+    public void clearAllWithNullSessionFactoryDegrades() {
+        TableInfoFactory.ofEntityClass(Account.class);
+        String report = FlexCaches.clearAll((SqlSessionFactory) null);
+        Assert.assertTrue(report.contains("TableInfo="));
+        Assert.assertFalse("null ssf 不应含 MappedStatement 段", report.contains("MappedStatement="));
+    }
+
+    @Test
+    public void clearAllWithFlexConfigurationClearsDynamicMs() {
+        FlexConfiguration flexCfg = new FlexConfiguration();
+        SqlSessionFactory ssf = mockSqlSessionFactory(flexCfg);
+
+        TableInfoFactory.ofEntityClass(Account.class);
+        seedDynamicMsCache("a.b.C:" + Account.class.getName());
+        seedDynamicMsCache("x.y.Z:" + Article.class.getName());
+
+        String report = FlexCaches.clearAll(ssf);
+
+        Assert.assertTrue("报告应含 MappedStatement 段", report.contains("MappedStatement="));
+        Assert.assertEquals("dynamicMappedStatementCache 应被全清",
+            0, FlexConfiguration.getDynamicMappedStatementCacheSize());
+
+        // clearAll 不清 resultMaps 全量，验证 Article 的还在
+        addFakeResultMap(flexCfg, Article.class.getName(), Article.class);
+        FlexCaches.clearAll(ssf);
+        Assert.assertTrue("clearAll 不应动 resultMaps 全量",
+            flexCfg.hasResultMap(Article.class.getName()));
+    }
+
+    // ==================== 辅助方法 ====================
+
+    private SqlSessionFactory mockSqlSessionFactory(Configuration cfg) {
+        // 用动态代理避免 SqlSessionFactory 接口里 openSession 重载方法的签名冲突
+        // （TransactionIsolationLevel 在 java.sql 和 org.apache.ibatis.session 都有，
+        //  且参数数量相同，匿名类实现时 erasure 后会冲突）
+        return (SqlSessionFactory) Proxy.newProxyInstance(
+            getClass().getClassLoader(),
+            new Class<?>[]{SqlSessionFactory.class},
+            (proxy, method, args) -> {
+                if ("getConfiguration".equals(method.getName())) {
+                    return cfg;
+                }
+                return null;
+            });
+    }
+
+    private void seedDynamicMsCache(String key) {
+        try {
+            Field field = FlexConfiguration.class.getDeclaredField("dynamicMappedStatementCache");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, Object> cache = (java.util.Map<String, Object>) field.get(null);
+            cache.put(key, new Object());
+        } catch (Exception e) {
+            throw new RuntimeException("seed dynamicMappedStatementCache failed", e);
+        }
+    }
+
+    private void addFakeResultMap(Configuration cfg, String id, Class<?> type) {
+        ResultMapping rm = new ResultMapping.Builder(cfg, "id", "id", Long.class)
+            .jdbcType(JdbcType.BIGINT)
+            .build();
+        ResultMap resultMap = new ResultMap.Builder(cfg, id, type, Collections.singletonList(rm))
+            .build();
+        try {
+            Field field = Configuration.class.getDeclaredField("resultMaps");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, ResultMap> map = (java.util.Map<String, ResultMap>) field.get(cfg);
+            map.put(id, resultMap);
+        } catch (Exception e) {
+            throw new RuntimeException("seed resultMaps failed", e);
+        }
     }
 
 }

--- a/mybatis-flex-core/src/test/java/com/mybatisflex/core/mybatis/FlexConfigurationEvictEntityTest.java
+++ b/mybatis-flex-core/src/test/java/com/mybatisflex/core/mybatis/FlexConfigurationEvictEntityTest.java
@@ -1,0 +1,192 @@
+/*
+ *  Copyright (c) 2022-2025, Mybatis-Flex (fuhai999@gmail.com).
+ *  <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *  <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *  <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.mybatisflex.core.mybatis;
+
+import com.mybatisflex.coretest.Account;
+import com.mybatisflex.coretest.Article;
+import org.apache.ibatis.mapping.ResultMap;
+import org.apache.ibatis.mapping.ResultMapping;
+import org.apache.ibatis.type.JdbcType;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+/**
+ * 覆盖 {@link FlexConfiguration#evictEntity(Class)} 以及
+ * {@link FlexConfiguration} 新增的三个静态工具方法
+ * （getDynamicMappedStatementCacheKeys / getDynamicMappedStatementCacheSize /
+ * clearDynamicMappedStatementCache）。
+ *
+ * <p>dynamicMappedStatementCache 是 static 字段且为 private，本测试通过
+ * 公开的 size / clear / evictEntity 三个方法做黑盒验证，不做反射。
+ */
+public class FlexConfigurationEvictEntityTest {
+
+    private FlexConfiguration configuration;
+
+    @Before
+    public void setUp() {
+        configuration = new FlexConfiguration();
+        // 每个用例开始前清掉 static 缓存，避免与其他测试互相污染
+        FlexConfiguration.clearDynamicMappedStatementCache();
+    }
+
+    @After
+    public void tearDown() {
+        FlexConfiguration.clearDynamicMappedStatementCache();
+    }
+
+    // ==================== evictEntity：清 dynamicMappedStatementCache ====================
+
+    @Test
+    public void evictEntityNullIsNoOp() {
+        // 塞入一个匹配 Account 的条目
+        seedDynamicMsCache("com.example.mapper.AccountMapper.selectList:" + Account.class.getName());
+
+        int before = FlexConfiguration.getDynamicMappedStatementCacheSize();
+        configuration.evictEntity(null);
+        int after = FlexConfiguration.getDynamicMappedStatementCacheSize();
+
+        Assert.assertEquals("null 入参不应清理任何条目", before, after);
+    }
+
+    @Test
+    public void evictEntityRemovesMatchingDynamicMs() {
+        String accountFqn = Account.class.getName();
+        seedDynamicMsCache("mapper1.selectList:" + accountFqn);
+        seedDynamicMsCache("mapper2.selectOne:" + accountFqn);
+        seedDynamicMsCache("mapper3.selectList:" + Article.class.getName()); // 不匹配
+
+        Assert.assertEquals(3, FlexConfiguration.getDynamicMappedStatementCacheSize());
+
+        configuration.evictEntity(Account.class);
+
+        Assert.assertEquals("应只移除 Account 的两条,保留 Article 的一条",
+            1, FlexConfiguration.getDynamicMappedStatementCacheSize());
+        Assert.assertTrue("剩下的那条应是 Article 的",
+            FlexConfiguration.getDynamicMappedStatementCacheKeys().iterator().next()
+                .endsWith(":" + Article.class.getName()));
+    }
+
+    @Test
+    public void evictEntityIsIdempotent() {
+        seedDynamicMsCache("mapper.selectList:" + Account.class.getName());
+
+        configuration.evictEntity(Account.class);
+        int sizeAfterFirst = FlexConfiguration.getDynamicMappedStatementCacheSize();
+
+        // 第二次调用不应报错，也不应改变状态
+        configuration.evictEntity(Account.class);
+        int sizeAfterSecond = FlexConfiguration.getDynamicMappedStatementCacheSize();
+
+        Assert.assertEquals(sizeAfterFirst, sizeAfterSecond);
+    }
+
+    // ==================== evictEntity：清 Configuration.resultMaps ====================
+
+    @Test
+    public void evictEntityRemovesMatchingResultMaps() {
+        String accountFqn = Account.class.getName();
+        // 模拟 flex 写入的 ResultMap：key = entityFQN
+        addFakeResultMap(accountFqn, Account.class);
+        // 以及一种变体：entityFQN-something（flex 内部可能生成的变体 key）
+        addFakeResultMap(accountFqn + "-inline", Account.class);
+        // 不相关的实体
+        addFakeResultMap(Article.class.getName(), Article.class);
+
+        Assert.assertTrue("Account ResultMap 应存在", configuration.hasResultMap(accountFqn));
+        Assert.assertTrue("Account 变体 ResultMap 应存在", configuration.hasResultMap(accountFqn + "-inline"));
+        Assert.assertTrue("Article ResultMap 应存在", configuration.hasResultMap(Article.class.getName()));
+
+        configuration.evictEntity(Account.class);
+
+        Assert.assertFalse("Account ResultMap 应被清掉", configuration.hasResultMap(accountFqn));
+        Assert.assertFalse("Account 变体 ResultMap 应被清掉", configuration.hasResultMap(accountFqn + "-inline"));
+        Assert.assertTrue("Article ResultMap 应保留", configuration.hasResultMap(Article.class.getName()));
+    }
+
+    // ==================== 静态工具方法 ====================
+
+    @Test
+    public void getSizeAndClearWork() {
+        Assert.assertEquals(0, FlexConfiguration.getDynamicMappedStatementCacheSize());
+
+        seedDynamicMsCache("a.b.C:com.example.Foo");
+        seedDynamicMsCache("x.y.Z:com.example.Bar");
+
+        Assert.assertEquals(2, FlexConfiguration.getDynamicMappedStatementCacheSize());
+
+        FlexConfiguration.clearDynamicMappedStatementCache();
+
+        Assert.assertEquals(0, FlexConfiguration.getDynamicMappedStatementCacheSize());
+    }
+
+    @Test
+    public void getKeysReturnsSnapshot() {
+        seedDynamicMsCache("mapper1:com.example.Foo");
+
+        java.util.Set<String> snapshot = FlexConfiguration.getDynamicMappedStatementCacheKeys();
+        Assert.assertEquals(1, snapshot.size());
+
+        // 修改快照不应影响真实缓存
+        snapshot.clear();
+        Assert.assertEquals(1, FlexConfiguration.getDynamicMappedStatementCacheSize());
+    }
+
+    // ==================== 辅助方法 ====================
+
+    /**
+     * 往 dynamicMappedStatementCache 里塞一个占位条目。
+     * 由于该字段是 private static，这里通过"清 -> 建 -> 再清 + 比对 size"的黑盒方式验证，
+     * 但构造测试数据时必须能写入。这里走反射仅做 seed。
+     */
+    private void seedDynamicMsCache(String key) {
+        try {
+            java.lang.reflect.Field field = FlexConfiguration.class.getDeclaredField("dynamicMappedStatementCache");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, Object> cache = (java.util.Map<String, Object>) field.get(null);
+            cache.put(key, new Object()); // value 不重要，key 是匹配的依据
+        } catch (Exception e) {
+            throw new RuntimeException("seed dynamicMappedStatementCache failed", e);
+        }
+    }
+
+    /**
+     * 往 Configuration.resultMaps 塞一个假 ResultMap，用于验证清理逻辑。
+     */
+    private void addFakeResultMap(String id, Class<?> type) {
+        ResultMapping rm = new ResultMapping.Builder(configuration, "id", "id", Long.class)
+            .jdbcType(JdbcType.BIGINT)
+            .build();
+        ResultMap resultMap = new ResultMap.Builder(configuration, id, type, Collections.singletonList(rm))
+            .build();
+        // Configuration 没有 public 的 addResultMap 方法，但 addMappedStatement 会间接加。
+        // 这里直接反射塞 resultMaps，简单直接。
+        try {
+            java.lang.reflect.Field field = org.apache.ibatis.session.Configuration.class.getDeclaredField("resultMaps");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, ResultMap> map = (java.util.Map<String, ResultMap>) field.get(configuration);
+            map.put(id, resultMap);
+        } catch (Exception e) {
+            throw new RuntimeException("seed resultMaps failed", e);
+        }
+    }
+}


### PR DESCRIPTION
解决热更新实体字段类型时，旧ResultMap未回收引发类型转换异常问题。
新增 evictEntity(SqlSessionFactory, Class)、clearAll(SqlSessionFactory) 重载：
1. evictEntity 按实体全限定名精准清理 dynamicMappedStatementCache、resultMaps
2. clearAll 清空 dynamicMappedStatementCache，但保留用户自定义resultMaps防止业务异常
3. sqlSessionFactory为空/非FlexConfiguration时自动降级，仅清理Flex自有缓存
原有无参/单Class参数方法行为不变，保持向后兼容。

新增单元测试覆盖边界场景，所有测试通过